### PR TITLE
feat: extend dashboards for non-admin roles

### DIFF
--- a/frontend/src/roles/esmp/Inicio.jsx
+++ b/frontend/src/roles/esmp/Inicio.jsx
@@ -1,16 +1,98 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { PieChart, Pie, Cell, ResponsiveContainer } from "recharts";
+import { AlertTriangle, Bell } from "lucide-react";
+import KpiCard from "../../components/KpiCard.jsx";
+import MiniCalendar from "../../components/MiniCalendar.jsx";
+import axios from "axios";
 
 export default function InicioESMP() {
+  const [resumen, setResumen] = useState({ total: 0, completadas: 0, pendientes: 0 });
+  const [criticosRetraso] = useState(0);
+  const [alertas] = useState(0);
+
   useEffect(() => {
     document.title = "Inicio - ESMP";
+
+    const fetchResumen = async () => {
+      try {
+        const { data } = await axios.get(`${import.meta.env.VITE_API_URL}/ordenes/resumen`);
+        setResumen(data);
+      } catch (err) {
+        console.error("❌ Error al obtener resumen:", err);
+      }
+    };
+
+    fetchResumen();
   }, []);
 
+  const dataChart = [
+    { name: "Completadas", value: resumen.completadas },
+    { name: "Pendientes", value: resumen.pendientes }
+  ];
+
   return (
-    <div className="p-6 bg-white rounded-lg shadow-md">
-      <h1 className="text-2xl font-bold mb-4">Bienvenido, ESMP</h1>
-      <p className="text-gray-700">
-        Aquí puedes planificar, registrar y auditar mantenimientos, así como gestionar usuarios y equipos. Usa el menú lateral para acceder.
-      </p>
+    <div className="p-6 text-[#111A3A] grid grid-cols-1 xl:grid-cols-[1fr_300px] gap-6">
+      <div>
+        <h1 className="text-3xl font-bold mb-2">Dashboard</h1>
+
+        {/* KPIs */}
+        <section>
+          <h2 className="text-xl font-semibold mb-4">KPIs</h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mb-6">
+            <KpiCard value={criticosRetraso} label="Órdenes críticas con retraso" Icon={AlertTriangle} color="#DC2626" />
+            <KpiCard value={alertas} label="Alertas por vencimiento" Icon={Bell} />
+          </div>
+        </section>
+
+        {/* Gráfico */}
+        <section className="mb-6">
+          <div className="bg-white p-6 rounded-lg shadow">
+            <h2 className="text-lg font-semibold mb-4">Cumplimiento mensual</h2>
+            <ResponsiveContainer width="100%" height={250}>
+              <PieChart>
+                <Pie
+                  data={dataChart}
+                  dataKey="value"
+                  nameKey="name"
+                  cx="50%"
+                  cy="50%"
+                  outerRadius={80}
+                  innerRadius={50}
+                  labelLine={false}
+                  label={({ name }) => `${name}`}
+                >
+                  {dataChart.map((entry, index) => (
+                    <Cell key={`cell-${index}`} fill={index === 0 ? "#10B981" : "#DC2626"} />
+                  ))}
+                </Pie>
+              </PieChart>
+            </ResponsiveContainer>
+          </div>
+        </section>
+
+        {/* Accesos directos */}
+        <section>
+          <div className="bg-white p-6 rounded-lg shadow">
+            <h2 className="text-lg font-semibold mb-4">Accesos directos</h2>
+            <div className="flex flex-wrap gap-4">
+              <Link to="/esmp/auditoria" className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-md">
+                Auditoría
+              </Link>
+              <Link to="/esmp/lista-equipos" className="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-md">
+                Lista de equipos
+              </Link>
+              <Link to="/esmp/planificacion" className="bg-purple-600 hover:bg-purple-700 text-white px-4 py-2 rounded-md">
+                Planificación
+              </Link>
+            </div>
+          </div>
+        </section>
+      </div>
+
+      <aside className="block">
+        <MiniCalendar />
+      </aside>
     </div>
   );
 }

--- a/frontend/src/roles/responsable_institucional/Inicio.jsx
+++ b/frontend/src/roles/responsable_institucional/Inicio.jsx
@@ -1,16 +1,99 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { AlertCircle, ClipboardList } from "lucide-react";
+import KpiCard from "../../components/KpiCard.jsx";
+import MiniCalendar from "../../components/MiniCalendar.jsx";
+import axios from "axios";
 
 export default function InicioResponsable() {
+  const [resumen, setResumen] = useState({ total: 0, completadas: 0, pendientes: 0 });
+  const [cumplimiento, setCumplimiento] = useState({ critico: { total: 0, firmadas: 0 }, relevante: { total: 0, firmadas: 0 } });
+
   useEffect(() => {
     document.title = "Inicio - Responsable Institucional";
+
+    const fetchResumen = async () => {
+      try {
+        const { data } = await axios.get(`${import.meta.env.VITE_API_URL}/ordenes/resumen`);
+        setResumen(data);
+      } catch (err) {
+        console.error("❌ Error al obtener resumen:", err);
+      }
+    };
+
+    const fetchCumplimiento = async () => {
+      try {
+        const { data } = await axios.get(`${import.meta.env.VITE_API_URL}/ordenes/cumplimiento-criticidad`);
+        setCumplimiento(data);
+      } catch (err) {
+        console.error("❌ Error al obtener cumplimiento:", err);
+      }
+    };
+
+    fetchResumen();
+    fetchCumplimiento();
   }, []);
 
+  const porcentaje = (parte, total) => (total === 0 ? 0 : Math.round((parte / total) * 100));
+  const { critico, relevante } = cumplimiento;
+
   return (
-    <div className="p-6 bg-white rounded-lg shadow-md">
-      <h1 className="text-2xl font-bold mb-4">Bienvenido, Responsable Institucional</h1>
-      <p className="text-gray-700">
-        Accede a auditorías, planificación, reportes estratégicos y validación de mantenimientos. Supervisa el funcionamiento integral del sistema.
-      </p>
+    <div className="p-6 text-[#111A3A] grid grid-cols-1 xl:grid-cols-[1fr_300px] gap-6">
+      <div>
+        <h1 className="text-3xl font-bold mb-2">Dashboard</h1>
+
+        {/* KPIs */}
+        <section>
+          <h2 className="text-xl font-semibold mb-4">KPIs</h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mb-6">
+            <KpiCard value={resumen.pendientes} label="Planificaciones por ejecutar" Icon={ClipboardList} />
+            <KpiCard value={0} label="Alertas técnicas" Icon={AlertCircle} color="#DC2626" />
+          </div>
+        </section>
+
+        {/* Cumplimiento */}
+        <section className="mb-6">
+          <div className="bg-white p-6 rounded-lg shadow">
+            <h2 className="text-lg font-semibold mb-4">Cumplimiento por Criticidad</h2>
+            <div className="mb-4">
+              <p className="text-sm font-medium text-[#111A3A]">Equipos Críticos</p>
+              <div className="w-full bg-gray-200 rounded h-3 mt-1">
+                <div className="bg-green-500 h-3 rounded" style={{ width: `${porcentaje(critico.firmadas, critico.total)}%` }}></div>
+              </div>
+              <p className="text-xs text-gray-500 mt-1">{critico.firmadas} de {critico.total} firmadas</p>
+            </div>
+            <div>
+              <p className="text-sm font-medium text-[#111A3A]">Equipos Relevantes</p>
+              <div className="w-full bg-gray-200 rounded h-3 mt-1">
+                <div className="bg-blue-500 h-3 rounded" style={{ width: `${porcentaje(relevante.firmadas, relevante.total)}%` }}></div>
+              </div>
+              <p className="text-xs text-gray-500 mt-1">{relevante.firmadas} de {relevante.total} firmadas</p>
+            </div>
+          </div>
+        </section>
+
+        {/* Accesos directos */}
+        <section>
+          <div className="bg-white p-6 rounded-lg shadow">
+            <h2 className="text-lg font-semibold mb-4">Accesos directos</h2>
+            <div className="flex flex-wrap gap-4">
+              <Link to="/responsable_institucional/asignar-ordenes" className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-md">
+                Asignar órdenes
+              </Link>
+              <Link to="/responsable_institucional/planificacion" className="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-md">
+                Planificación
+              </Link>
+              <Link to="/responsable_institucional/reportes" className="bg-purple-600 hover:bg-purple-700 text-white px-4 py-2 rounded-md">
+                Reportes firmados
+              </Link>
+            </div>
+          </div>
+        </section>
+      </div>
+
+      <aside className="block">
+        <MiniCalendar />
+      </aside>
     </div>
   );
 }

--- a/frontend/src/roles/supervisor/Inicio.jsx
+++ b/frontend/src/roles/supervisor/Inicio.jsx
@@ -1,16 +1,138 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { ClipboardList, AlertTriangle } from "lucide-react";
+import KpiCard from "../../components/KpiCard.jsx";
+import MiniCalendar from "../../components/MiniCalendar.jsx";
+import { getOrdenesEjecutadas } from "../../services/ordenesServices.js";
+import { obtenerLogs } from "../../services/logsService.js";
+import axios from "axios";
 
 export default function InicioSupervisor() {
+  const [porValidar, setPorValidar] = useState(0);
+  const [criticosDia] = useState(0);
+  const [logs, setLogs] = useState([]);
+  const [cumplimiento, setCumplimiento] = useState({ critico: { total: 0, firmadas: 0 }, relevante: { total: 0, firmadas: 0 } });
+
   useEffect(() => {
     document.title = "Inicio - Supervisor";
+
+    const fetchPorValidar = async () => {
+      try {
+        const data = await getOrdenesEjecutadas();
+        setPorValidar(data.length);
+      } catch (err) {
+        console.error("❌ Error al obtener órdenes por validar:", err);
+      }
+    };
+
+    const fetchLogs = async () => {
+      try {
+        const data = await obtenerLogs();
+        setLogs(data.slice(0, 5));
+      } catch (err) {
+        console.error("❌ Error al obtener logs:", err);
+      }
+    };
+
+    const fetchCumplimiento = async () => {
+      try {
+        const { data } = await axios.get(`${import.meta.env.VITE_API_URL}/ordenes/cumplimiento-criticidad`);
+        setCumplimiento(data);
+      } catch (err) {
+        console.error("❌ Error al obtener cumplimiento:", err);
+      }
+    };
+
+    fetchPorValidar();
+    fetchLogs();
+    fetchCumplimiento();
   }, []);
 
+  const porcentaje = (parte, total) => (total === 0 ? 0 : Math.round((parte / total) * 100));
+  const { critico, relevante } = cumplimiento;
+
   return (
-    <div className="p-6 bg-white rounded-lg shadow-md">
-      <h1 className="text-2xl font-bold mb-4">Bienvenido, Supervisor</h1>
-      <p className="text-gray-700">
-        Desde aquí puedes validar y aprobar los mantenimientos realizados por los técnicos. Navega con el menú lateral.
-      </p>
+    <div className="p-6 text-[#111A3A] grid grid-cols-1 xl:grid-cols-[1fr_300px] gap-6">
+      <div>
+        <h1 className="text-3xl font-bold mb-2">Dashboard</h1>
+
+        {/* KPIs */}
+        <section>
+          <h2 className="text-xl font-semibold mb-4">KPIs</h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mb-6">
+            <KpiCard value={porValidar} label="Órdenes por validar" Icon={ClipboardList} />
+            <KpiCard value={criticosDia} label="Críticos del día" Icon={AlertTriangle} color="#DC2626" />
+          </div>
+        </section>
+
+        {/* Cumplimiento */}
+        <section className="mb-6">
+          <div className="bg-white p-6 rounded-lg shadow">
+            <h2 className="text-lg font-semibold mb-4">Cumplimiento por Sección</h2>
+            <div className="mb-4">
+              <p className="text-sm font-medium text-[#111A3A]">Equipos Críticos</p>
+              <div className="w-full bg-gray-200 rounded h-3 mt-1">
+                <div className="bg-green-500 h-3 rounded" style={{ width: `${porcentaje(critico.firmadas, critico.total)}%` }}></div>
+              </div>
+              <p className="text-xs text-gray-500 mt-1">{critico.firmadas} de {critico.total} firmadas</p>
+            </div>
+            <div>
+              <p className="text-sm font-medium text-[#111A3A]">Equipos Relevantes</p>
+              <div className="w-full bg-gray-200 rounded h-3 mt-1">
+                <div className="bg-blue-500 h-3 rounded" style={{ width: `${porcentaje(relevante.firmadas, relevante.total)}%` }}></div>
+              </div>
+              <p className="text-xs text-gray-500 mt-1">{relevante.firmadas} de {relevante.total} firmadas</p>
+            </div>
+          </div>
+        </section>
+
+        {/* Logs */}
+        <section className="mb-6">
+          <div className="bg-white p-6 rounded-lg shadow h-full">
+            <h2 className="text-lg font-semibold mb-4">Actividad reciente</h2>
+            {logs.length === 0 ? (
+              <p className="text-sm text-gray-400">No hay registros recientes.</p>
+            ) : (
+              <ul className="text-sm text-gray-700 space-y-2">
+                {logs.map((log) => {
+                  const fecha = new Date(log.fecha).toLocaleDateString("es-CL", {
+                    year: "2-digit",
+                    month: "2-digit",
+                    day: "2-digit",
+                  });
+                  return (
+                    <li key={log.id}>
+                      <span className="text-[#111A3A] font-semibold">{fecha}</span> – {log.usuario} <span className="italic">{log.accion}</span> en <span className="font-medium">{log.tabla_afectada}</span>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
+        </section>
+
+        {/* Accesos directos */}
+        <section>
+          <div className="bg-white p-6 rounded-lg shadow">
+            <h2 className="text-lg font-semibold mb-4">Accesos directos</h2>
+            <div className="flex flex-wrap gap-4">
+              <Link to="/supervisor/validacion" className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-md">
+                Validar mantenimientos
+              </Link>
+              <Link to="/supervisor/asignar-ordenes" className="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-md">
+                Asignar órdenes
+              </Link>
+              <Link to="/supervisor/auditoria" className="bg-purple-600 hover:bg-purple-700 text-white px-4 py-2 rounded-md">
+                Auditoría
+              </Link>
+            </div>
+          </div>
+        </section>
+      </div>
+
+      <aside className="block">
+        <MiniCalendar />
+      </aside>
     </div>
   );
 }

--- a/frontend/src/roles/tecnico/Inicio.jsx
+++ b/frontend/src/roles/tecnico/Inicio.jsx
@@ -1,16 +1,138 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { ClipboardList, CheckCircle } from "lucide-react";
+import KpiCard from "../../components/KpiCard.jsx";
+import MiniCalendar from "../../components/MiniCalendar.jsx";
+import { getOrdenesPendientes, getHistorialOrdenes } from "../../services/ordenesServices.js";
+import { obtenerLogs } from "../../services/logsService.js";
+import { useAuth } from "../../pages/auth/AuthContext.jsx";
 
 export default function InicioTecnico() {
+  const { user } = useAuth();
+  const [pendientes, setPendientes] = useState(0);
+  const [ejecutadosMes, setEjecutadosMes] = useState(0);
+  const [ultimasOrdenes, setUltimasOrdenes] = useState([]);
+  const [logs, setLogs] = useState([]);
+  const [error, setError] = useState("");
+
   useEffect(() => {
     document.title = "Inicio - Técnico";
-  }, []);
+
+    const fetchPendientes = async () => {
+      try {
+        const data = await getOrdenesPendientes();
+        setPendientes(data.length);
+      } catch (err) {
+        console.error("❌ Error al obtener pendientes:", err);
+        setError("No se pudo cargar la información de órdenes.");
+      }
+    };
+
+    const fetchHistorial = async () => {
+      try {
+        const data = await getHistorialOrdenes();
+        const ahora = new Date();
+        const inicioMes = new Date(ahora.getFullYear(), ahora.getMonth(), 1);
+        const realizados = data.filter((o) => {
+          const fecha = o.fecha_ejecucion ? new Date(o.fecha_ejecucion) : null;
+          return fecha && fecha >= inicioMes && fecha <= ahora;
+        });
+        setEjecutadosMes(realizados.length);
+        setUltimasOrdenes(data.slice(0, 5));
+      } catch (err) {
+        console.error("❌ Error al obtener historial:", err);
+      }
+    };
+
+    const fetchLogs = async () => {
+      try {
+        const data = await obtenerLogs();
+        const propios = user ? data.filter((l) => l.usuario === user.nombre) : data;
+        setLogs(propios.slice(0, 5));
+      } catch (err) {
+        console.error("❌ Error al obtener logs:", err);
+      }
+    };
+
+    fetchPendientes();
+    fetchHistorial();
+    fetchLogs();
+  }, [user]);
 
   return (
-    <div className="p-6 bg-white rounded-lg shadow-md">
-      <h1 className="text-2xl font-bold mb-4">Bienvenido, Técnico</h1>
-      <p className="text-gray-700">
-        Desde este panel puedes registrar mantenimientos y consultar tus tareas asignadas. Utiliza el menú lateral para acceder a tus funciones.
-      </p>
+    <div className="p-6 text-[#111A3A] grid grid-cols-1 xl:grid-cols-[1fr_300px] gap-6">
+      <div>
+        <h1 className="text-3xl font-bold mb-2">Dashboard</h1>
+        {error && <p className="text-red-500 mb-4">{error}</p>}
+
+        {/* KPIs */}
+        <section>
+          <h2 className="text-xl font-semibold mb-4">KPIs</h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mb-6">
+            <KpiCard value={pendientes} label="Mis Órdenes Pendientes" Icon={ClipboardList} color="#FBBF24" />
+            <KpiCard value={ejecutadosMes} label="Mantenimientos este mes" Icon={CheckCircle} color="#34D399" />
+          </div>
+        </section>
+
+        {/* Órdenes completadas y acciones */}
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
+          <div className="bg-white p-6 rounded-lg shadow">
+            <h2 className="text-lg font-semibold mb-4">Últimas órdenes completadas</h2>
+            {ultimasOrdenes.length === 0 ? (
+              <p className="text-sm text-gray-400">No hay registros.</p>
+            ) : (
+              <ul className="text-sm text-gray-700 space-y-2">
+                {ultimasOrdenes.map((orden) => (
+                  <li key={orden.id}>
+                    {orden.equipo_nombre || "Equipo"} – {new Date(orden.fecha_ejecucion).toLocaleDateString("es-CL")}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+
+          <div className="bg-white p-6 rounded-lg shadow h-full">
+            <h2 className="text-lg font-semibold mb-4">Acciones recientes</h2>
+            {logs.length === 0 ? (
+              <p className="text-sm text-gray-400">No hay registros recientes.</p>
+            ) : (
+              <ul className="text-sm text-gray-700 space-y-2">
+                {logs.map((log) => {
+                  const fecha = new Date(log.fecha).toLocaleDateString("es-CL", {
+                    year: "2-digit",
+                    month: "2-digit",
+                    day: "2-digit",
+                  });
+                  return (
+                    <li key={log.id}>
+                      <span className="text-[#111A3A] font-semibold">{fecha}</span> – {log.usuario} <span className="italic">{log.accion}</span> en <span className="font-medium">{log.tabla_afectada}</span>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
+        </div>
+
+        {/* Accesos directos */}
+        <section>
+          <div className="bg-white p-6 rounded-lg shadow">
+            <h2 className="text-lg font-semibold mb-4">Accesos directos</h2>
+            <div className="flex flex-wrap gap-4">
+              <Link to="/tecnico/registros-firmas" className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-md">
+                Ejecutar mantenimiento
+              </Link>
+              <Link to="/tecnico/historial" className="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-md">
+                Historial técnico
+              </Link>
+            </div>
+          </div>
+        </section>
+      </div>
+
+      <aside className="block">
+        <MiniCalendar />
+      </aside>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add detailed dashboard for technicians with KPIs, recent actions, and shortcuts
- introduce supervisor dashboard with validation metrics and team activity
- create dashboards for institutional managers and ESMP with compliance and quick links

## Testing
- `npm test` *(fails: Cannot find dependency 'jsdom')*


------
https://chatgpt.com/codex/tasks/task_e_68b640a54360832eb5d271afa1516430