### PR TITLE
feat: manage users

### DIFF
--- a/frontend/src/pages/functions/Usuarios.jsx
+++ b/frontend/src/pages/functions/Usuarios.jsx
@@ -1,8 +1,217 @@
+import { useEffect, useState } from "react";
+import api from "../../services/api";
+import SuccessBanner from "../../components/SuccesBanner";
+import ErrorBanner from "../../components/ErrorBanner";
+
+const roles = [
+  { id: 1, nombre: "Administrador" },
+  { id: 2, nombre: "Técnico" },
+  { id: 3, nombre: "Supervisor" },
+];
+
 export default function Usuarios() {
-    return (
-      <div className="p-4">
-        <h1 className="text-xl font-bold">Gestión de usuarios</h1>
-        <p>Este es un componente de prueba.</p>
+  const [usuarios, setUsuarios] = useState([]);
+  const [mensaje, setMensaje] = useState(null);
+  const [form, setForm] = useState({ nombre: "", email: "", rol_id: "", tipo: "local" });
+  const [editId, setEditId] = useState(null);
+
+  const cargarUsuarios = () => {
+    api
+      .get("/usuarios")
+      .then((res) => setUsuarios(res.data))
+      .catch(() =>
+        setMensaje({ tipo: "error", texto: "Error al cargar usuarios." })
+      );
+  };
+
+  useEffect(() => {
+    cargarUsuarios();
+  }, []);
+
+  const handleChange = (e) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+
+    try {
+      if (editId) {
+        await api.put(`/usuarios/${editId}`, {
+          nombre: form.nombre,
+          email: form.email,
+          rol_id: form.rol_id,
+        });
+        setMensaje({ tipo: "success", texto: "Usuario actualizado." });
+      } else {
+        const { data } = await api.post("/usuarios", form);
+        let texto = "Usuario creado.";
+        if (data.password) {
+          texto += ` Clave por defecto: ${data.password}`;
+        }
+        setMensaje({ tipo: "success", texto });
+      }
+
+      setForm({ nombre: "", email: "", rol_id: "", tipo: "local" });
+      setEditId(null);
+      cargarUsuarios();
+    } catch (error) {
+      console.error("Error al guardar usuario:", error);
+      setMensaje({ tipo: "error", texto: "Error al guardar usuario." });
+    }
+  };
+
+  const handleEdit = (u) => {
+    setEditId(u.id);
+    setForm({
+      nombre: u.nombre,
+      email: u.email,
+      rol_id: u.rol_id,
+      tipo: u.password_hash ? "local" : "google",
+    });
+  };
+
+  const handleDelete = async (id) => {
+    if (!confirm("¿Eliminar usuario?")) return;
+    try {
+      await api.delete(`/usuarios/${id}`);
+      cargarUsuarios();
+    } catch (error) {
+      console.error("Error al eliminar usuario:", error);
+      setMensaje({ tipo: "error", texto: "Error al eliminar usuario." });
+    }
+  };
+
+  const obtenerRol = (rolId) => roles.find((r) => r.id === rolId)?.nombre || "-";
+
+  return (
+    <div className="p-6">
+      {mensaje?.tipo === "success" && (
+        <SuccessBanner
+          title="Operación exitosa"
+          message={mensaje.texto}
+          onClose={() => setMensaje(null)}
+        />
+      )}
+      {mensaje?.tipo === "error" && (
+        <ErrorBanner
+          title="Error"
+          message={mensaje.texto}
+          onClose={() => setMensaje(null)}
+        />
+      )}
+
+      <h1 className="text-2xl font-bold mb-6">Gestión de usuarios</h1>
+
+      <form
+        onSubmit={handleSubmit}
+        className="bg-white p-4 rounded-xl shadow mb-6 space-y-4"
+      >
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div className="flex flex-col">
+            <label className="text-sm text-gray-700 mb-1">Nombre</label>
+            <input
+              type="text"
+              name="nombre"
+              value={form.nombre}
+              onChange={handleChange}
+              required
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm outline-none"
+            />
+          </div>
+
+          <div className="flex flex-col">
+            <label className="text-sm text-gray-700 mb-1">Email</label>
+            <input
+              type="email"
+              name="email"
+              value={form.email}
+              onChange={handleChange}
+              required
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm outline-none"
+            />
+          </div>
+
+          <div className="flex flex-col">
+            <label className="text-sm text-gray-700 mb-1">Rol</label>
+            <select
+              name="rol_id"
+              value={form.rol_id}
+              onChange={handleChange}
+              required
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm outline-none"
+            >
+              <option value="">Selecciona</option>
+              {roles.map((r) => (
+                <option key={r.id} value={r.id}>
+                  {r.nombre}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex flex-col">
+            <label className="text-sm text-gray-700 mb-1">Tipo</label>
+            <select
+              name="tipo"
+              value={form.tipo}
+              onChange={handleChange}
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm outline-none"
+            >
+              <option value="local">Local</option>
+              <option value="google">Google</option>
+            </select>
+          </div>
+        </div>
+
+        <div className="flex justify-end pt-4">
+          <button
+            type="submit"
+            className="bg-[#D0FF34] text-[#111A3A] font-semibold px-6 py-2 rounded shadow hover:opacity-90"
+          >
+            {editId ? "Actualizar Usuario" : "Crear Usuario"}
+          </button>
+        </div>
+      </form>
+
+      <div className="overflow-x-auto bg-white shadow rounded-xl">
+        <table className="min-w-full">
+          <thead className="bg-gray-50">
+            <tr className="text-left text-sm text-gray-600">
+              <th className="p-3">ID</th>
+              <th className="p-3">Nombre</th>
+              <th className="p-3">Email</th>
+              <th className="p-3">Rol</th>
+              <th className="p-3">Acciones</th>
+            </tr>
+          </thead>
+          <tbody>
+            {usuarios.map((u) => (
+              <tr key={u.id} className="border-t">
+                <td className="p-3 text-sm text-gray-800">{u.id}</td>
+                <td className="p-3 text-sm text-gray-600">{u.nombre}</td>
+                <td className="p-3 text-sm text-gray-600">{u.email}</td>
+                <td className="p-3 text-sm text-gray-600">{obtenerRol(u.rol_id)}</td>
+                <td className="p-3 text-sm">
+                  <button
+                    onClick={() => handleEdit(u)}
+                    className="text-blue-600 hover:underline mr-3"
+                  >
+                    Editar
+                  </button>
+                  <button
+                    onClick={() => handleDelete(u.id)}
+                    className="text-red-600 hover:underline"
+                  >
+                    Eliminar
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
       </div>
-    );
-  }
+    </div>
+  );
+}
+

--- a/server/controllers/usuariosController.js
+++ b/server/controllers/usuariosController.js
@@ -1,5 +1,17 @@
-const { getUsuarios } = require('../models/usuariosModel');
-const db = require("../db");
+const {
+  getUsuarios,
+  crearUsuario,
+  actualizarUsuario,
+  eliminarUsuario,
+} = require('../models/usuariosModel');
+const db = require('../db');
+const bcrypt = require('bcryptjs');
+
+// Genera una clave por defecto sencilla a partir del nombre
+function generarClave(nombre) {
+  const primerNombre = nombre.split(' ')[0].toLowerCase();
+  return `${primerNombre}123`;
+}
 
 async function listarUsuarios(req, res) {
   try {
@@ -8,6 +20,56 @@ async function listarUsuarios(req, res) {
   } catch (err) {
     console.error('Error al listar usuarios:', err.message);
     res.status(500).json({ error: 'Error al obtener usuarios' });
+  }
+}
+
+async function crearUsuarioCtrl(req, res) {
+  try {
+    const { nombre, email, rol_id, tipo } = req.body;
+
+    let password_hash = null;
+    let password = null;
+
+    if (tipo === 'local') {
+      password = generarClave(nombre);
+      password_hash = await bcrypt.hash(password, 10);
+    }
+
+    const nuevoUsuario = await crearUsuario({
+      nombre,
+      email,
+      password_hash,
+      rol_id,
+    });
+
+    res.status(201).json({ ...nuevoUsuario, password });
+  } catch (err) {
+    console.error('Error al crear usuario:', err.message);
+    res.status(500).json({ error: 'Error al crear usuario' });
+  }
+}
+
+async function actualizarUsuarioCtrl(req, res) {
+  try {
+    const { id } = req.params;
+    const { nombre, email, rol_id } = req.body;
+
+    const actualizado = await actualizarUsuario(id, { nombre, email, rol_id });
+    res.json(actualizado);
+  } catch (err) {
+    console.error('Error al actualizar usuario:', err.message);
+    res.status(500).json({ error: 'Error al actualizar usuario' });
+  }
+}
+
+async function eliminarUsuarioCtrl(req, res) {
+  try {
+    const { id } = req.params;
+    await eliminarUsuario(id);
+    res.status(204).end();
+  } catch (err) {
+    console.error('Error al eliminar usuario:', err.message);
+    res.status(500).json({ error: 'Error al eliminar usuario' });
   }
 }
 
@@ -21,12 +83,16 @@ const obtenerTecnicos = async (req, res) => {
     `);
     res.json(rows);
   } catch (error) {
-    console.error("❌ Error al obtener técnicos:", error);
-    res.status(500).json({ error: "Error al obtener técnicos" });
+    console.error('❌ Error al obtener técnicos:', error);
+    res.status(500).json({ error: 'Error al obtener técnicos' });
   }
 };
 
 module.exports = {
   listarUsuarios,
-  obtenerTecnicos
+  crearUsuario: crearUsuarioCtrl,
+  actualizarUsuario: actualizarUsuarioCtrl,
+  eliminarUsuario: eliminarUsuarioCtrl,
+  obtenerTecnicos,
 };
+

--- a/server/models/usuariosModel.js
+++ b/server/models/usuariosModel.js
@@ -20,16 +20,32 @@ async function crearUsuario({ nombre, email, password_hash, rol_id }) {
   return result.rows[0];
 }
 
+// Listar usuarios
+async function getUsuarios() {
+  const result = await pool.query('SELECT * FROM usuarios');
+  return result.rows;
+}
+
+// Actualizar usuario
+async function actualizarUsuario(id, { nombre, email, rol_id }) {
+  const result = await pool.query(
+    `UPDATE usuarios SET nombre = $1, email = $2, rol_id = $3
+     WHERE id = $4 RETURNING *`,
+    [nombre, email, rol_id, id]
+  );
+  return result.rows[0];
+}
+
+// Eliminar usuario
+async function eliminarUsuario(id) {
+  await pool.query('DELETE FROM usuarios WHERE id = $1', [id]);
+}
+
 module.exports = {
   getUsuarioByEmail,
   crearUsuario,
-  getUsuarios
+  getUsuarios,
+  actualizarUsuario,
+  eliminarUsuario,
 };
 
-async function getUsuarios() {
-    const result = await pool.query('SELECT * FROM usuarios');
-    return result.rows;
-  }
-  
-
-  

--- a/server/routes/usuariosRoutes.js
+++ b/server/routes/usuariosRoutes.js
@@ -3,19 +3,20 @@ const express = require('express');
 const router = express.Router();
 const { verifyToken } = require('../middlewares/auth');
 
-// OJO: el nombre y la ruta del archivo deben coincidir EXACTO
-// con el que creaste en controllers (plural/singular, mayúsculas/minúsculas)
 const {
-    listarUsuarios,
-    obtenerTecnicos
- } = require('../controllers/usuariosController');
+  listarUsuarios,
+  obtenerTecnicos,
+  crearUsuario,
+  actualizarUsuario,
+  eliminarUsuario,
+} = require('../controllers/usuariosController');
 
-// No llames a la función aquí (NO uses paréntesis)
-router.get('/usuarios', listarUsuarios);
+router.get('/usuarios', verifyToken, listarUsuarios);
+router.post('/usuarios', verifyToken, crearUsuario);
+router.put('/usuarios/:id', verifyToken, actualizarUsuario);
+router.delete('/usuarios/:id', verifyToken, eliminarUsuario);
 
-
-// Importar el controlador de usuarios
-
-router.get("/tecnicos", verifyToken, obtenerTecnicos);
+router.get('/tecnicos', verifyToken, obtenerTecnicos);
 
 module.exports = router;
+


### PR DESCRIPTION
## Summary
- add CRUD functions for usuarios and generate default passwords
- secure user routes with token auth
- build user management page to create, edit or delete accounts

## Testing
- `npm test --prefix server` *(fails: Cannot find module 'uuid')*
- `npm test --prefix frontend` *(fails: missing dependency 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_68b642c9fa18832e903252c7513b9a9f