### PR TITLE
feat: add read-only calendar page for non-planning roles

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -20,6 +20,7 @@ import Reportes from "./pages/functions/Reportes";
 import Alertas from "./pages/functions/Alertas";
 import Visualizar from "./pages/functions/ListaEquipos";
 import Planificacion from "./pages/functions/Planificacion";
+import Calendario from "./pages/functions/Calendario";
 import AsignarOrdenes from "./pages/functions/AsignarOrden";
 import HistorialTecnico from "./pages/functions/HistorialTécnico";
 import ValidarOrdenes from "./pages/functions/ValidarOrdenes";
@@ -92,6 +93,7 @@ function App() {
           }
         >
           <Route index element={<InicioTecnico />} />
+          <Route path="calendario" element={<Calendario />} />
           <Route path="alertas" element={<Alertas />} />
           <Route path="historial" element={<HistorialTecnico />} />
           <Route path="registros-firmas" element={<RegistrosFirmas />} />
@@ -107,6 +109,7 @@ function App() {
           }
         >
           <Route index element={<InicioSupervisor />} />
+          <Route path="calendario" element={<Calendario />} />
           <Route path="alertas" element={<Alertas />} />
           <Route path="asignar-ordenes" element={<AsignarOrdenes />} />
           <Route path="validacion" element={<ValidarOrdenes />} />

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -47,6 +47,12 @@ export default function Sidebar() {
       roles: [1, 2, 3, 5, 6],
     },
     {
+      path: `${basePath}/calendario`,
+      label: "Calendario de Mantenimientos",
+      icon: Calendar,
+      roles: [2, 3],
+    },
+    {
       label: "Gestión de Equipos",
       icon: MonitorDot,
       roles: [1, 6],

--- a/frontend/src/components/calendar/EventModal.jsx
+++ b/frontend/src/components/calendar/EventModal.jsx
@@ -2,6 +2,8 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { getRutaPorRol } from "../../utils/rutasPorRol";
+import FloatingBanner from "../FloatingBanner";
+import { XCircle } from "lucide-react";
 
 
 export default function EventModal({ evento, onClose }) {
@@ -14,14 +16,14 @@ export default function EventModal({ evento, onClose }) {
   const user = JSON.parse(localStorage.getItem("user"));
   const rolPath = getRutaPorRol(user?.rol_nombre);
 
-  const handleGestionClick = () => {
-    navigate(`${rolPath}/gestion?equipo_id=${evento.equipo_id}`);
-  };
-
   const confirmarReprogramacion = () => {
     setMostrarConfirmacion(false);
-    onClose(); // Cerramos el modal primero
-    navigate(`/${rolNombre}/gestion?equipo_id=${evento.equipo_id}&fecha_anterior=${evento.start.toISOString().split("T")[0]}`);
+    onClose();
+    navigate(
+      `${rolPath}/gestion?equipo_id=${evento.equipo_id}&fecha_anterior=${
+        evento.start.toISOString().split("T")[0]
+      }`
+    );
   };
 
   return (
@@ -32,7 +34,7 @@ export default function EventModal({ evento, onClose }) {
             className="absolute top-6 right-6 text-[#111A3A] hover:text-gray-600"
             onClick={onClose}
           >
-            <CircleX size={20} />
+            <XCircle size={20} />
           </button>
 
           <h2 className="text-lg font-bold text-[#111A3A] mb-2">

--- a/frontend/src/pages/functions/Calendario.jsx
+++ b/frontend/src/pages/functions/Calendario.jsx
@@ -1,0 +1,100 @@
+// src/pages/functions/Calendario.jsx
+import { useEffect, useState } from "react";
+import axios from "axios";
+import MiniCalendar from "../../components/MiniCalendar";
+import CalendarContainer from "../../components/calendar/CalendarContainer";
+
+export default function Calendario() {
+  const [eventos, setEventos] = useState([]);
+  const [eventosFiltrados, setEventosFiltrados] = useState([]);
+  const [filtrosCriticidad, setFiltrosCriticidad] = useState({
+    crítico: true,
+    relevante: true,
+    instalación: true
+  });
+
+  const fetchEventos = async () => {
+    try {
+      const token = localStorage.getItem("token");
+      const config = { headers: { Authorization: `Bearer ${token}` } };
+      const { data } = await axios.get(
+        `${import.meta.env.VITE_API_URL}/ordenes/eventos`,
+        config
+      );
+
+      const eventosConvertidos = data.map((evento) => ({
+        id: evento.id?.toString() || `p-${evento.equipo_id}-${evento.start}`,
+        title: evento.title,
+        start: new Date(evento.start),
+        end: new Date(evento.end),
+        allDay: true,
+        criticidad: evento.criticidad || "media",
+        estado: evento.estado || "proyectado",
+        tipo: evento.tipo || "proyectado",
+        serie: evento.serie || "-",
+        plan: evento.plan || "-",
+        ubicacion: evento.ubicacion || "-",
+        equipo_id: evento.equipo_id
+      }));
+
+      setEventos(eventosConvertidos);
+    } catch (error) {
+      console.error("❌ Error al cargar eventos:", error);
+    }
+  };
+
+  const aplicarFiltroCriticidad = () => {
+    const activos = Object.keys(filtrosCriticidad).filter((c) => filtrosCriticidad[c]);
+    const filtrados = eventos.filter((ev) => activos.includes(ev.criticidad));
+    setEventosFiltrados(filtrados);
+  };
+
+  useEffect(() => {
+    fetchEventos();
+  }, []);
+
+  useEffect(() => {
+    aplicarFiltroCriticidad();
+  }, [eventos, filtrosCriticidad]);
+
+  const toggleCriticidad = (tipo) => {
+    setFiltrosCriticidad((prev) => ({
+      ...prev,
+      [tipo]: !prev[tipo]
+    }));
+  };
+
+  return (
+    <div className="flex flex-col lg:flex-row p-6 gap-6">
+      {/* Panel izquierdo */}
+      <div className="w-full lg:w-72 flex flex-col gap-4 order-2 lg:order-1">
+        <MiniCalendar />
+
+        <div className="bg-[#5C7BA1] rounded-xl shadow p-4 text-white">
+          <h3 className="text-sm font-semibold mb-2">Filtro de criticidad</h3>
+          <ul className="space-y-2 text-sm">
+            {["crítico", "relevante", "instalación"].map((tipo) => (
+              <li key={tipo}>
+                <label className="flex items-center">
+                  <input
+                    type="checkbox"
+                    checked={filtrosCriticidad[tipo]}
+                    onChange={() => toggleCriticidad(tipo)}
+                    className="mr-2 accent-white"
+                  />
+                  {tipo.charAt(0).toUpperCase() + tipo.slice(1)}
+                </label>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+
+      {/* Calendario principal */}
+      <div className="w-full order-1 lg:order-2">
+        <CalendarContainer eventos={eventosFiltrados} />
+      </div>
+    </div>
+  );
+}
+

--- a/server/controllers/ordenesController.js
+++ b/server/controllers/ordenesController.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const db = require('../db');
 const { endOfWeek } = require("date-fns");
 const generarReportePDF = require('../utils/generarReportes');
-const { v4: uuidv4 } = require("uuid");
+const { randomUUID } = require("crypto");
 
 const {
   getOrdenes,
@@ -440,8 +440,14 @@ const generarPDF = async (req, res) => {
     }
 
     // Guardar firmas temporales
-    const firmaTecnicoPath = path.join(__dirname, `../uploads/firmas/firmaTecnico_${uuidv4()}.png`);
-    const firmaServicioPath = path.join(__dirname, `../uploads/firmas/firmaServicio_${uuidv4()}.png`);
+    const firmaTecnicoPath = path.join(
+      __dirname,
+      `../uploads/firmas/firmaTecnico_${randomUUID()}.png`
+    );
+    const firmaServicioPath = path.join(
+      __dirname,
+      `../uploads/firmas/firmaServicio_${randomUUID()}.png`
+    );
 
     const firmaTBuffer = Buffer.from(firmaTecnico.replace(/^data:image\/\w+;base64,/, ""), "base64");
     const firmaSBuffer = Buffer.from(firmaServicio.replace(/^data:image\/\w+;base64,/, ""), "base64");
@@ -484,16 +490,25 @@ const generarPDF = async (req, res) => {
 async function obtenerEventosCalendario(req, res) {
   try {
     const eventos = [];
+    const { rol_id, sub: usuario_id } = req.user || {};
+    const rolId = Number(rol_id);
 
     // 1. Obtener todas las órdenes reales (planificadas)
-    const { rows: ordenes } = await db.query(`
+    let queryOrdenes = `
       SELECT ot.id, ot.equipo_id, ot.plan_id, ot.fecha_programada, ot.estado,
              eq.nombre, eq.serie, eq.criticidad, eq.ubicacion,
              pm.nombre AS plan
       FROM ordenes_trabajo ot
       JOIN equipos eq ON ot.equipo_id = eq.id
-      JOIN planes_mantenimiento pm ON eq.plan_id = pm.id
-    `);
+      JOIN planes_mantenimiento pm ON eq.plan_id = pm.id`;
+
+    const params = [];
+    if (rolId === 2) {
+      queryOrdenes += ` WHERE ot.responsable = $1`;
+      params.push(usuario_id.toString());
+    }
+
+    const { rows: ordenes } = await db.query(queryOrdenes, params);
 
     // Eventos reales planificados
     ordenes.forEach((ot) => {
@@ -513,49 +528,51 @@ async function obtenerEventosCalendario(req, res) {
       });
     });
 
-    // 2. Obtener última OT registrada por equipo (independiente del estado)
-    const { rows: ultimasOTs } = await db.query(`
-      SELECT DISTINCT ON (e.id) 
-             e.id AS equipo_id,
-             e.nombre,
-             e.serie,
-             e.ubicacion,
-             e.criticidad,
-             pm.frecuencia,
-             pm.nombre AS plan,
-             ot.fecha_programada AS ultima_fecha
-      FROM equipos e
-      JOIN planes_mantenimiento pm ON e.plan_id = pm.id
-      JOIN ordenes_trabajo ot ON ot.equipo_id = e.id
-      WHERE pm.activo = TRUE
-      ORDER BY e.id, ot.fecha_programada DESC
-    `);
+    // 2. Proyecciones solo para roles con planificación
+    if (rolId !== 2) {
+      const { rows: ultimasOTs } = await db.query(`
+        SELECT DISTINCT ON (e.id)
+               e.id AS equipo_id,
+               e.nombre,
+               e.serie,
+               e.ubicacion,
+               e.criticidad,
+               pm.frecuencia,
+               pm.nombre AS plan,
+               ot.fecha_programada AS ultima_fecha
+        FROM equipos e
+        JOIN planes_mantenimiento pm ON e.plan_id = pm.id
+        JOIN ordenes_trabajo ot ON ot.equipo_id = e.id
+        WHERE pm.activo = TRUE
+        ORDER BY e.id, ot.fecha_programada DESC
+      `);
 
-    for (const eq of ultimasOTs) {
-      const semanas = FRECUENCIA_SEMANAS[eq.frecuencia];
-      if (!semanas || !eq.ultima_fecha) continue;
+      for (const eq of ultimasOTs) {
+        const semanas = FRECUENCIA_SEMANAS[eq.frecuencia];
+        if (!semanas || !eq.ultima_fecha) continue;
 
-      const fechaBase = new Date(eq.ultima_fecha);
-      const cantidadProyecciones = Math.floor(52 / semanas);
+        const fechaBase = new Date(eq.ultima_fecha);
+        const cantidadProyecciones = Math.floor(52 / semanas);
 
-      for (let i = 1; i <= cantidadProyecciones; i++) {
-        const proximaFecha = new Date(fechaBase);
-        proximaFecha.setDate(proximaFecha.getDate() + i * semanas * 7);
+        for (let i = 1; i <= cantidadProyecciones; i++) {
+          const proximaFecha = new Date(fechaBase);
+          proximaFecha.setDate(proximaFecha.getDate() + i * semanas * 7);
 
-        eventos.push({
-          id: `p-${eq.equipo_id}-${i}`,
-          equipo_id: eq.equipo_id,
-          title: eq.nombre,
-          start: proximaFecha.toISOString().slice(0, 10),
-          end: proximaFecha.toISOString().slice(0, 10),
-          allDay: true,
-          criticidad: eq.criticidad,
-          estado: "proyectado",
-          tipo: "proyectado",
-          ubicacion: eq.ubicacion,
-          serie: eq.serie,
-          plan: eq.plan,
-        });
+          eventos.push({
+            id: `p-${eq.equipo_id}-${i}`,
+            equipo_id: eq.equipo_id,
+            title: eq.nombre,
+            start: proximaFecha.toISOString().slice(0, 10),
+            end: proximaFecha.toISOString().slice(0, 10),
+            allDay: true,
+            criticidad: eq.criticidad,
+            estado: "proyectado",
+            tipo: "proyectado",
+            ubicacion: eq.ubicacion,
+            serie: eq.serie,
+            plan: eq.plan,
+          });
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- add standalone calendar page with criticidad filters for viewing scheduled tasks
- show calendar link in sidebar for technician and supervisor roles
- restrict calendar API to orders assigned to a technician and drop projections for them
- replace broken tabler icon in event modal with lucide-react XCircle

## Testing
- `cd server && npm test` *(fails: connect ECONNREFUSED ::1:5432)*
- `cd frontend && npm test` *(fails: Cannot find dependency 'jsdom')*
- `npm install jsdom --no-save` *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68b64170d8b0832eb1f50402ec9b07ff