### PR TITLE
Adjust technician modal actions based on order status

### DIFF
--- a/frontend/src/components/calendar/EventModal.jsx
+++ b/frontend/src/components/calendar/EventModal.jsx
@@ -133,14 +133,30 @@ export default function EventModal({ evento, onClose }) {
             </button>
           )}
 
-          {!esProyectado && rol === "tecnico" && (
-            <button
-              className="mt-6 w-full bg-[#D0FF34] text-[#111A3A] font-semibold py-2 rounded shadow hover:bg-lime-300 text-sm"
-              onClick={() => setMostrarEjecutar(true)}
-            >
-              Ejecutar orden
-            </button>
-          )}
+          {!esProyectado &&
+            rol === "tecnico" &&
+            evento.estado?.toLowerCase() === "pendiente" && (
+              <button
+                className="mt-6 w-full bg-[#D0FF34] text-[#111A3A] font-semibold py-2 rounded shadow hover:bg-lime-300 text-sm"
+                onClick={() => setMostrarEjecutar(true)}
+              >
+                Ejecutar orden
+              </button>
+            )}
+
+          {!esProyectado &&
+            rol === "tecnico" &&
+            evento.estado?.toLowerCase() === "validada" && (
+              <button
+                className="mt-6 w-full bg-[#D0FF34] text-[#111A3A] font-semibold py-2 rounded shadow hover:bg-lime-300 text-sm"
+                onClick={() => {
+                  onClose();
+                  navigate(`${rolPath}/registros-firmas?orden_id=${evento.id}`);
+                }}
+              >
+                Registrar firma
+              </button>
+            )}
 
           {!esProyectado && rol === "supervisor" && !evento.responsable && (
             <button


### PR DESCRIPTION
## Summary
- Update calendar event modal for technicians: execute button only when order is pending
- Show signature registration when order is validated and remove actions for realized orders

## Testing
- `npm test` *(fails: Cannot find dependency 'jsdom'; installation attempt returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b6656ee69c832eae57fb9eba8b786c