### PR TITLE
Load roles dynamically from API

### DIFF
--- a/frontend/src/pages/functions/Usuarios.jsx
+++ b/frontend/src/pages/functions/Usuarios.jsx
@@ -3,15 +3,10 @@ import api from "../../services/api";
 import SuccessBanner from "../../components/SuccesBanner";
 import ErrorBanner from "../../components/ErrorBanner";
 
-const roles = [
-  { id: 1, nombre: "Administrador" },
-  { id: 2, nombre: "Técnico" },
-  { id: 3, nombre: "Supervisor" },
-];
-
 export default function Usuarios() {
   const [usuarios, setUsuarios] = useState([]);
   const [mensaje, setMensaje] = useState(null);
+  const [roles, setRoles] = useState([]);
   const [form, setForm] = useState({ nombre: "", email: "", rol_id: "", tipo: "local" });
   const [editId, setEditId] = useState(null);
 
@@ -24,8 +19,18 @@ export default function Usuarios() {
       );
   };
 
+  const cargarRoles = () => {
+    api
+      .get("/roles")
+      .then((res) => setRoles(res.data))
+      .catch(() =>
+        setMensaje({ tipo: "error", texto: "Error al cargar roles." })
+      );
+  };
+
   useEffect(() => {
     cargarUsuarios();
+    cargarRoles();
   }, []);
 
   const handleChange = (e) => {

--- a/server/controllers/rolesController.js
+++ b/server/controllers/rolesController.js
@@ -1,0 +1,13 @@
+const { getRoles } = require('../models/rolesModel');
+
+async function listarRoles(_req, res) {
+  try {
+    const roles = await getRoles();
+    res.json(roles);
+  } catch (err) {
+    console.error('Error al obtener roles:', err.message);
+    res.status(500).json({ error: 'Error al obtener roles' });
+  }
+}
+
+module.exports = { listarRoles };

--- a/server/index_app.js
+++ b/server/index_app.js
@@ -32,6 +32,7 @@ app.use('/api/ordenes', require('./routes/ordenesRoutes'));
 app.use('/api/planes', require('./routes/planesRoutes'));
 app.use('/api/equipos', require('./routes/equiposRoutes'));
 app.use('/api/evidencias', evidenciasRoutes);
+app.use('/api/roles', require('./routes/rolesRoutes'));
 
 
 //Manejo de errores básico

--- a/server/models/rolesModel.js
+++ b/server/models/rolesModel.js
@@ -1,0 +1,8 @@
+const pool = require('../db');
+
+async function getRoles() {
+  const result = await pool.query("SELECT id, nombre FROM roles WHERE nombre <> 'calidad' ORDER BY id");
+  return result.rows;
+}
+
+module.exports = { getRoles };

--- a/server/routes/rolesRoutes.js
+++ b/server/routes/rolesRoutes.js
@@ -1,0 +1,7 @@
+const express = require('express');
+const router = express.Router();
+const { listarRoles } = require('../controllers/rolesController');
+
+router.get('/', listarRoles);
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add API endpoint to list roles excluding "calidad"
- fetch roles from backend in user management UI

## Testing
- `cd server && npm test` *(fails: connect ECONNREFUSED ::1:5432)*
- `cd frontend && npm test` *(fails: Cannot find dependency 'jsdom')*


------
https://chatgpt.com/codex/tasks/task_e_68b66af2b118832e8fe7b35b4852c61d