### PR TITLE
Activar reprogramación al gestionar mantenimientos

### DIFF
--- a/frontend/src/components/calendar/EventModal.jsx
+++ b/frontend/src/components/calendar/EventModal.jsx
@@ -41,7 +41,7 @@ export default function EventModal({ evento, onClose }) {
     navigate(
       `${rolPath}/gestion?equipo_id=${evento.equipo_id}&fecha_anterior=${
         evento.start.toISOString().split("T")[0]
-      }`
+      }&orden_id=${evento.id}`
     );
   };
 


### PR DESCRIPTION
## Resumen
- Propagar el identificador de orden al abrir la gestión desde el calendario.
- Detectar parámetros de reprogramación y mostrar formulario dedicado en la gestión.
- Marcar la orden original como reprogramada y crear una nueva con la fecha seleccionada.

## Testing
- `npm --prefix frontend test` *(falló: MISSING DEPENDENCY Cannot find dependency 'jsdom')*
- `npm --prefix server test` *(falló: connect ECONNREFUSED ::1:5432)*

------
https://chatgpt.com/codex/tasks/task_e_68b7058fcc8c832eb279fcbb5880c5c0