### PR TITLE
Activar reprogramación al gestionar mantenimientos

### DIFF
--- a/frontend/src/components/calendar/EventModal.jsx
+++ b/frontend/src/components/calendar/EventModal.jsx
@@ -41,7 +41,7 @@ export default function EventModal({ evento, onClose }) {
     navigate(
       `${rolPath}/gestion?equipo_id=${evento.equipo_id}&fecha_anterior=${
         evento.start.toISOString().split("T")[0]
-      }`
+      }&orden_id=${evento.id}`
     );
   };
 
@@ -124,14 +124,17 @@ export default function EventModal({ evento, onClose }) {
             )}
           </div>
 
-          {!esProyectado && rol !== "tecnico" && rol !== "supervisor" && (
-            <button
-              className="mt-6 w-full bg-[#D0FF34] text-[#111A3A] font-semibold py-2 rounded shadow hover:bg-lime-300 text-sm"
-              onClick={() => setMostrarConfirmacion(true)}
-            >
-              Reprogramar este mantenimiento
-            </button>
-          )}
+          {!esProyectado &&
+            rol !== "tecnico" &&
+            rol !== "supervisor" &&
+            evento.estado?.toLowerCase() === "pendiente" && (
+              <button
+                className="mt-6 w-full bg-[#D0FF34] text-[#111A3A] font-semibold py-2 rounded shadow hover:bg-lime-300 text-sm"
+                onClick={() => setMostrarConfirmacion(true)}
+              >
+                Reprogramar este mantenimiento
+              </button>
+            )}
 
           {!esProyectado &&
             rol === "tecnico" &&

--- a/frontend/src/pages/functions/GestionPlanificacion.jsx
+++ b/frontend/src/pages/functions/GestionPlanificacion.jsx
@@ -1,6 +1,6 @@
 // frontend/src/pages/functions/GestionPlanificacion.jsx
 import { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { Search } from "lucide-react";
 import axios from "axios";
 import SuccessBanner from "../../components/SuccesBanner";
@@ -11,12 +11,20 @@ const formatearID = (id) => `ID${String(id).padStart(4, "0")}`;
 export default function GestionPlanificacion() {
   const navigate = useNavigate();
   const user = JSON.parse(localStorage.getItem("user"));
+  const [searchParams] = useSearchParams();
 
   const [equipos, setEquipos] = useState([]);
   const [seleccionados, setSeleccionados] = useState([]);
   const [fecha, setFecha] = useState("");
+  const [fechaReprogramacion, setFechaReprogramacion] = useState("");
   const [mensaje, setMensaje] = useState(null);
   const [busqueda, setBusqueda] = useState("");
+  const [modoReprogramacion, setModoReprogramacion] = useState(false);
+  const [ordenInfo, setOrdenInfo] = useState(null);
+
+  const ordenId = searchParams.get("orden_id");
+  const equipoIdParam = searchParams.get("equipo_id");
+  const fechaAnterior = searchParams.get("fecha_anterior");
 
   useEffect(() => {
     const rolId = Number(user?.rol_id);
@@ -36,6 +44,23 @@ export default function GestionPlanificacion() {
         setMensaje({ tipo: "error", texto: "Error al cargar equipos." });
       });
   }, []);
+
+  useEffect(() => {
+    if (ordenId && equipoIdParam && fechaAnterior) {
+      setModoReprogramacion(true);
+    }
+  }, [ordenId, equipoIdParam, fechaAnterior]);
+
+  useEffect(() => {
+    if (modoReprogramacion && ordenId) {
+      axios
+        .get(`${import.meta.env.VITE_API_URL}/ordenes/${ordenId}/detalle`)
+        .then((res) => setOrdenInfo(res.data))
+        .catch((err) => {
+          console.error("Error al cargar datos de la orden:", err);
+        });
+    }
+  }, [modoReprogramacion, ordenId]);
 
   const toggleSeleccion = (id) => {
     setSeleccionados((prev) =>
@@ -80,6 +105,38 @@ export default function GestionPlanificacion() {
     eq.nombre.toLowerCase().includes(busqueda.toLowerCase())
   );
 
+  const handleReprogramar = async () => {
+    if (!fechaReprogramacion) {
+      setMensaje({ tipo: "error", texto: "Selecciona una nueva fecha." });
+      return;
+    }
+
+    try {
+      await axios.put(
+        `${import.meta.env.VITE_API_URL}/ordenes/${ordenId}/estado`,
+        { estado: "reprogramada" }
+      );
+
+      await axios.post(`${import.meta.env.VITE_API_URL}/ordenes`, {
+        equipo_id: Number(equipoIdParam),
+        fecha_programada: fechaReprogramacion,
+        estado: "pendiente",
+      });
+
+      setMensaje({
+        tipo: "success",
+        texto: "Mantenimiento reprogramado con éxito.",
+      });
+      setFechaReprogramacion("");
+    } catch (err) {
+      console.error("Error al reprogramar:", err);
+      setMensaje({
+        tipo: "error",
+        texto: "Error al reprogramar mantenimiento.",
+      });
+    }
+  };
+
   return (
     <div className="p-6">
       {mensaje?.tipo === "success" && (
@@ -90,6 +147,44 @@ export default function GestionPlanificacion() {
       )}
 
       <h1 className="text-2xl font mb-4">Planificación de Mantenimientos</h1>
+
+      {modoReprogramacion && (
+        <div className="mb-6 p-4 bg-white border border-gray-200 rounded-xl shadow">
+          <h2 className="text-lg font-medium text-gray-700 mb-2">
+            Reprogramar mantenimiento
+          </h2>
+          {ordenInfo && (
+            <div className="text-sm text-gray-700 mb-4">
+              <p>
+                <span className="font-medium">Equipo:</span> {ordenInfo.equipo_nombre}
+              </p>
+              <p>
+                <span className="font-medium">Ubicación:</span> {ordenInfo.ubicacion}
+              </p>
+              <p>
+                <span className="font-medium">ID:</span> {formatearID(equipoIdParam)}
+              </p>
+            </div>
+          )}
+          <p className="text-sm text-gray-600 mb-4">
+            Fecha original: {new Date(fechaAnterior).toLocaleDateString("es-CL")}
+          </p>
+          <div className="flex flex-col sm:flex-row items-center gap-4">
+            <input
+              type="date"
+              value={fechaReprogramacion}
+              onChange={(e) => setFechaReprogramacion(e.target.value)}
+              className="w-full sm:w-auto bg-white border border-gray-300 rounded-lg px-4 py-2 shadow-sm"
+            />
+            <button
+              onClick={handleReprogramar}
+              className="bg-[#D0FF34] text-[#111A3A] font-semibold px-6 py-2 rounded shadow hover:bg-lime-300"
+            >
+              Guardar reprogramación
+            </button>
+          </div>
+        </div>
+      )}
 
       <div className="flex justify-between items-center mb-4">
         <div className="relative w-full max-w-sm">
@@ -105,7 +200,11 @@ export default function GestionPlanificacion() {
 
       </div>
 
-      <div className="overflow-x-auto bg-white shadow rounded-xl">
+      <div
+        className={`overflow-x-auto bg-white shadow rounded-xl ${
+          modoReprogramacion ? "opacity-50 pointer-events-none" : ""
+        }`}
+      >
         <table className="min-w-full">
           <thead className="bg-gray-50">
             <tr className="text-left text-sm text-gray-600">
@@ -154,37 +253,46 @@ export default function GestionPlanificacion() {
         </table>
       </div>
 
-      <div>
-      <h2 className="mt-8 text-lg font-medium text-gray-700">Confirmar Programa de Mantenimiento</h2>
-      </div>
-
-      {/* CONTENEDOR DE FECHA + BOTÓN */}
-      <div className="mt-2 flex flex-col sm:flex-row justify-between items-center gap-4 p-4 bg-white border border-gray-200 rounded-xl shadow mb-6">
-        {/* Label + Input fecha */}
-        <div className="w-full sm:w-auto">
-          <label htmlFor="fecha_programada" className="block text-sm font-medium text-gray-700 mb-1">
-            Fecha de Ejecución
-          </label>
-          <div className="flex items-center rounded-lg border border-gray-300 px-4 py-2 bg-white shadow-sm">
-            <input
-              type="date"
-              id="fecha_programada"
-              name="fecha_programada"
-              value={fecha}
-              onChange={(e) => setFecha(e.target.value)}
-              className="w-full bg-white text-sm text-gray-800 outline-none appearance-none"
-            />
+      {!modoReprogramacion && (
+        <>
+          <div>
+            <h2 className="mt-8 text-lg font-medium text-gray-700">
+              Confirmar Programa de Mantenimiento
+            </h2>
           </div>
-        </div>
 
-        {/* Botón de guardar */}
-        <button
-          onClick={handleSubmit}
-          className=" bg-[#D0FF34] text-[#111A3A] font-semibold px-6 py-2 rounded shadow hover:bg-lime-300"
-        >
-          Guardar planificación
-        </button>
-      </div>
+          {/* CONTENEDOR DE FECHA + BOTÓN */}
+          <div className="mt-2 flex flex-col sm:flex-row justify-between items-center gap-4 p-4 bg-white border border-gray-200 rounded-xl shadow mb-6">
+            {/* Label + Input fecha */}
+            <div className="w-full sm:w-auto">
+              <label
+                htmlFor="fecha_programada"
+                className="block text-sm font-medium text-gray-700 mb-1"
+              >
+                Fecha de Ejecución
+              </label>
+              <div className="flex items-center rounded-lg border border-gray-300 px-4 py-2 bg-white shadow-sm">
+                <input
+                  type="date"
+                  id="fecha_programada"
+                  name="fecha_programada"
+                  value={fecha}
+                  onChange={(e) => setFecha(e.target.value)}
+                  className="w-full bg-white text-sm text-gray-800 outline-none appearance-none"
+                />
+              </div>
+            </div>
+
+            {/* Botón de guardar */}
+            <button
+              onClick={handleSubmit}
+              className=" bg-[#D0FF34] text-[#111A3A] font-semibold px-6 py-2 rounded shadow hover:bg-lime-300"
+            >
+              Guardar planificación
+            </button>
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/server/controllers/ordenesController.js
+++ b/server/controllers/ordenesController.js
@@ -66,14 +66,19 @@ async function crearNuevaOrden(req, res) {
     const plan_id = result.rows[0].plan_id;
 
     // Verifica que no exista ya una orden pendiente para este equipo
-    const { rowCount: ordenesActivas } = await db.query(`
+    const { rowCount: ordenesActivas } = await db.query(
+      `
       SELECT 1 FROM ordenes_trabajo
-      WHERE equipo_id = $1 AND estado IN ('pendiente', 'reprogramada')
+      WHERE equipo_id = $1 AND estado = 'pendiente'
       LIMIT 1
-    `, [equipo_id]);
+    `,
+      [equipo_id]
+    );
 
     if (ordenesActivas > 0) {
-      return res.status(409).json({ error: "Ya existe una orden activa para este equipo." });
+      return res
+        .status(409)
+        .json({ error: "Ya existe una orden activa para este equipo." });
     }
 
     const insert = await db.query(


### PR DESCRIPTION
## Resumen
- Permitir crear nueva orden de mantenimiento aunque exista una reprogramada
- Mostrar datos del equipo y bloquear la tabla de planificación durante la reprogramación
- Mostrar botón de reprogramación solo para órdenes pendientes

## Testing
- `npm --prefix frontend test` *(falló: MISSING DEPENDENCY Cannot find dependency 'jsdom')*
- `npm --prefix frontend install jsdom --no-save` *(falló: 403 Forbidden)*
- `npm --prefix server test` *(falló: connect ECONNREFUSED ::1:5432)*

------
https://chatgpt.com/codex/tasks/task_e_68b7058fcc8c832eb279fcbb5880c5c0