### PR TITLE
Activar reprogramación al gestionar mantenimientos

### DIFF
--- a/frontend/src/components/calendar/EventModal.jsx
+++ b/frontend/src/components/calendar/EventModal.jsx
@@ -41,7 +41,7 @@ export default function EventModal({ evento, onClose }) {
     navigate(
       `${rolPath}/gestion?equipo_id=${evento.equipo_id}&fecha_anterior=${
         evento.start.toISOString().split("T")[0]
-      }`
+      }&orden_id=${evento.id}`
     );
   };
 
@@ -124,14 +124,17 @@ export default function EventModal({ evento, onClose }) {
             )}
           </div>
 
-          {!esProyectado && rol !== "tecnico" && rol !== "supervisor" && (
-            <button
-              className="mt-6 w-full bg-[#D0FF34] text-[#111A3A] font-semibold py-2 rounded shadow hover:bg-lime-300 text-sm"
-              onClick={() => setMostrarConfirmacion(true)}
-            >
-              Reprogramar este mantenimiento
-            </button>
-          )}
+          {!esProyectado &&
+            rol !== "tecnico" &&
+            rol !== "supervisor" &&
+            evento.estado?.toLowerCase() === "pendiente" && (
+              <button
+                className="mt-6 w-full bg-[#D0FF34] text-[#111A3A] font-semibold py-2 rounded shadow hover:bg-lime-300 text-sm"
+                onClick={() => setMostrarConfirmacion(true)}
+              >
+                Reprogramar este mantenimiento
+              </button>
+            )}
 
           {!esProyectado &&
             rol === "tecnico" &&

--- a/server/routes/ordenesRoutes.js
+++ b/server/routes/ordenesRoutes.js
@@ -10,6 +10,7 @@ const {
   obtenerOrden,
   crearNuevaOrden,
   cambiarEstado,
+  reprogramarOrden,
   detalleOrden,
   calendarizarMantenimientos,
   ejecutarOrden,
@@ -32,6 +33,7 @@ router.get('/', listarOrdenes);
 router.get('/ordenes/:id', obtenerOrden);
 router.post('/', crearNuevaOrden);
 router.put('/:id/estado', cambiarEstado);
+router.put('/:id/reprogramar', reprogramarOrden);
 router.get('/:id/detalle', detalleOrden);
 router.put('/:id', validarEstadoOrden, validarOrden);
 


### PR DESCRIPTION
## Resumen
- Actualizar orden existente al reprogramar, sobre escribiendo la fecha
- Se consume el nuevo endpoint desde gestión, evitando crear órdenes duplicadas

## Testing
- `npm --prefix frontend test` *(falló: MISSING DEPENDENCY Cannot find dependency 'jsdom')*
- `npm --prefix frontend install jsdom --no-save` *(falló: 403 Forbidden - GET https://registry.npmjs.org/jsdom)*
- `npm --prefix server test` *(falló: connect ECONNREFUSED ::1:5432)*

------
https://chatgpt.com/codex/tasks/task_e_68b7058fcc8c832eb279fcbb5880c5c0