### PR TITLE
Link alerts to work orders

### DIFF
--- a/frontend/src/pages/functions/Alertas.jsx
+++ b/frontend/src/pages/functions/Alertas.jsx
@@ -51,7 +51,11 @@ const Alertas = () => {
                 return (
                   <tr key={alerta.id}>
                     <td className="px-4 py-3">{alerta.id}</td>
-                    <td className="px-4 py-3">{alerta.equipo_nombre || "Equipo no registrado"}</td>
+                    <td className="px-4 py-3">
+                      {alerta.equipo_nombre
+                        ? `${alerta.equipo_nombre} (ID ${alerta.equipo_id})`
+                        : "Equipo no registrado"}
+                    </td>
                     <td className="px-4 py-3">{alerta.ubicacion || "No especificada"}</td>
                     <td className="px-4 py-3 font-semibold">
                       {alerta.criticidad === "crítico" ? (

--- a/server/controllers/alertasController.js
+++ b/server/controllers/alertasController.js
@@ -22,17 +22,17 @@ exports.generarAlertas = async (req, res) => {
     for (const orden of ordenesVencidas) {
       const yaExiste = await db.query(`
         SELECT 1 FROM alertas
-        WHERE equipo_id = $1 AND tipo_id = $2 AND leida = false
-      `, [orden.equipo_id, TIPO_ALERTA_FECHA_VENCIDA]);
+        WHERE orden_id = $1 AND tipo_id = $2 AND leida = false
+      `, [orden.orden_id, TIPO_ALERTA_FECHA_VENCIDA]);
 
       if (yaExiste.rowCount === 0) {
         const mensaje = `Orden pendiente desde ${orden.fecha_programada} para el equipo "${orden.equipo_nombre}"`;
 
         const insert = await db.query(`
-          INSERT INTO alertas (equipo_id, tipo_id, mensaje)
+          INSERT INTO alertas (orden_id, tipo_id, mensaje)
           VALUES ($1, $2, $3)
           RETURNING *
-        `, [orden.equipo_id, TIPO_ALERTA_FECHA_VENCIDA, mensaje]);
+        `, [orden.orden_id, TIPO_ALERTA_FECHA_VENCIDA, mensaje]);
 
         nuevasAlertas.push(insert.rows[0]);
       }
@@ -49,15 +49,20 @@ exports.generarAlertas = async (req, res) => {
 exports.obtenerAlertas = async (req, res) => {
     try {
       const { rows } = await db.query(`
-        SELECT 
+        SELECT
           a.id,
           a.mensaje,
           a.leida,
           a.generada_en,
+          o.id AS orden_id,
+          e.id AS equipo_id,
           e.nombre AS equipo_nombre,
+          e.ubicacion,
+          e.criticidad,
           ta.nombre AS tipo_alerta
         FROM alertas a
-        LEFT JOIN equipos e ON a.equipo_id = e.id
+        LEFT JOIN ordenes_trabajo o ON a.orden_id = o.id
+        LEFT JOIN equipos e ON o.equipo_id = e.id
         LEFT JOIN tipos_alerta ta ON a.tipo_id = ta.id
         ORDER BY a.generada_en DESC
       `);

--- a/server/init.sql
+++ b/server/init.sql
@@ -61,7 +61,7 @@ CREATE TABLE IF NOT EXISTS tipos_alerta (
 -- Tabla: alertas
 CREATE TABLE IF NOT EXISTS alertas (
   id SERIAL PRIMARY KEY,
-  equipo_id INTEGER REFERENCES equipos(id),
+  orden_id INTEGER REFERENCES ordenes_trabajo(id),
   tipo_id INTEGER REFERENCES tipos_alerta(id),
   mensaje TEXT NOT NULL,
   leida BOOLEAN DEFAULT FALSE,


### PR DESCRIPTION
## Summary
- Store alerts by work order and retain equipment details
- Display equipment ID alongside name in alert list

## Testing
- ⚠️ `npm test` (server) – fails: connect ECONNREFUSED 127.0.0.1:5432
- ⚠️ `npm test` (frontend) – fails: MISSING DEPENDENCY Cannot find dependency 'jsdom'

------
https://chatgpt.com/codex/tasks/task_e_68b76ee1bb44832ea1127aed334240ad