### PR TITLE
fix: normalize role names for login

### DIFF
--- a/frontend/src/utils/rutasPorRol.js
+++ b/frontend/src/utils/rutasPorRol.js
@@ -1,7 +1,12 @@
 // frontend/src/utils/rutasPorRol.js
 
 const normalizarRol = (rol) =>
-  rol.normalize("NFD").replace(/[\u0300-\u036f]/g, "").toLowerCase();
+  rol
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/_/g, " ")
+    .toLowerCase()
+    .trim();
 
 export const getRutaPorRol = (rolNombre) => {
   const rol = normalizarRol(rolNombre);


### PR DESCRIPTION
## Summary
- sanitize role strings before routing to ensure `responsable institucional` logins redirect correctly

## Testing
- `cd frontend && npm test` *(fails: Cannot find dependency 'jsdom'; no test files found)*
- `npm install jsdom --no-save` *(fails: 403 Forbidden from registry)*
- `cd server && npm test` *(fails: connect ECONNREFUSED 127.0.0.1:5432)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c121e704832e99ab550ae23f5e40