### PR TITLE
Use equipo_id for alert lookups

### DIFF
--- a/frontend/src/pages/functions/Alertas.jsx
+++ b/frontend/src/pages/functions/Alertas.jsx
@@ -51,7 +51,11 @@ const Alertas = () => {
                 return (
                   <tr key={alerta.id}>
                     <td className="px-4 py-3">{alerta.id}</td>
-                    <td className="px-4 py-3">{alerta.equipo_nombre || "Equipo no registrado"}</td>
+                    <td className="px-4 py-3">
+                      {alerta.equipo_nombre
+                        ? `${alerta.equipo_nombre} (ID ${alerta.equipo_id})`
+                        : "Equipo no registrado"}
+                    </td>
                     <td className="px-4 py-3">{alerta.ubicacion || "No especificada"}</td>
                     <td className="px-4 py-3 font-semibold">
                       {alerta.criticidad === "crítico" ? (

--- a/server/controllers/alertasController.js
+++ b/server/controllers/alertasController.js
@@ -47,24 +47,27 @@ exports.generarAlertas = async (req, res) => {
 };
 
 exports.obtenerAlertas = async (req, res) => {
-    try {
-      const { rows } = await db.query(`
-        SELECT 
-          a.id,
-          a.mensaje,
-          a.leida,
-          a.generada_en,
-          e.nombre AS equipo_nombre,
-          ta.nombre AS tipo_alerta
-        FROM alertas a
-        LEFT JOIN equipos e ON a.equipo_id = e.id
-        LEFT JOIN tipos_alerta ta ON a.tipo_id = ta.id
-        ORDER BY a.generada_en DESC
-      `);
-  
-      res.json(rows);
-    } catch (error) {
-      console.error("❌ Error al obtener alertas:", error);
-      res.status(500).json({ error: "Error al obtener alertas" });
-    }
-  };
+  try {
+    const { rows } = await db.query(`
+      SELECT
+        a.id,
+        a.mensaje,
+        a.leida,
+        a.generada_en,
+        a.equipo_id,
+        e.nombre AS equipo_nombre,
+        e.ubicacion,
+        e.criticidad,
+        ta.nombre AS tipo_alerta
+      FROM alertas a
+      LEFT JOIN equipos e ON a.equipo_id = e.id
+      LEFT JOIN tipos_alerta ta ON a.tipo_id = ta.id
+      ORDER BY a.generada_en DESC
+    `);
+
+    res.json(rows);
+  } catch (error) {
+    console.error("❌ Error al obtener alertas:", error);
+    res.status(500).json({ error: "Error al obtener alertas" });
+  }
+};

--- a/server/init.sql
+++ b/server/init.sql
@@ -58,7 +58,13 @@ CREATE TABLE IF NOT EXISTS tipos_alerta (
   descripcion TEXT
 );
 
--- Tabla: alertas
+-- Asegurar que la tabla de alertas utilice equipo_id
+ALTER TABLE IF EXISTS alertas
+  ADD COLUMN IF NOT EXISTS equipo_id INTEGER REFERENCES equipos(id);
+
+ALTER TABLE IF EXISTS alertas
+  DROP COLUMN IF EXISTS orden_id;
+
 CREATE TABLE IF NOT EXISTS alertas (
   id SERIAL PRIMARY KEY,
   equipo_id INTEGER REFERENCES equipos(id),
@@ -67,6 +73,10 @@ CREATE TABLE IF NOT EXISTS alertas (
   leida BOOLEAN DEFAULT FALSE,
   generada_en TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
+
+CREATE UNIQUE INDEX IF NOT EXISTS alertas_equipo_tipo_unq
+  ON alertas (equipo_id, tipo_id)
+  WHERE leida = FALSE;
 
 -- Tabla: evidencias
 CREATE TABLE IF NOT EXISTS evidencias (


### PR DESCRIPTION
## Summary
- Generate and query alerts using equipo_id to match current database schema
- Ensure init.sql defines alertas with equipo_id and unique index per equipo/tipo

## Testing
- `cd server && npm test` *(fails: connect ECONNREFUSED 127.0.0.1:5432)*
- `cd frontend && npm test` *(fails: Cannot find dependency 'jsdom'; no test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68b76ee1bb44832ea1127aed334240ad