### PR TITLE
Generate alerts on view load

### DIFF
--- a/frontend/src/pages/functions/Alertas.jsx
+++ b/frontend/src/pages/functions/Alertas.jsx
@@ -1,6 +1,6 @@
 // frontend/src/pages/functions/Alertas.jsx
 import { useEffect, useState } from 'react';
-import { obtenerAlertas } from '../../services/alertasService';
+import { obtenerAlertas, generarAlertas } from '../../services/alertasService';
 
 const Alertas = () => {
   const [alertas, setAlertas] = useState([]);
@@ -8,6 +8,7 @@ const Alertas = () => {
   useEffect(() => {
     const fetchData = async () => {
       try {
+        await generarAlertas();
         const data = await obtenerAlertas();
         setAlertas(data);
       } catch (error) {
@@ -51,7 +52,11 @@ const Alertas = () => {
                 return (
                   <tr key={alerta.id}>
                     <td className="px-4 py-3">{alerta.id}</td>
-                    <td className="px-4 py-3">{alerta.equipo_nombre || "Equipo no registrado"}</td>
+                    <td className="px-4 py-3">
+                      {alerta.equipo_nombre
+                        ? `${alerta.equipo_nombre} (ID ${alerta.equipo_id})`
+                        : "Equipo no registrado"}
+                    </td>
                     <td className="px-4 py-3">{alerta.ubicacion || "No especificada"}</td>
                     <td className="px-4 py-3 font-semibold">
                       {alerta.criticidad === "crítico" ? (

--- a/frontend/src/services/alertasService.js
+++ b/frontend/src/services/alertasService.js
@@ -1,6 +1,10 @@
 // src/frontend/alertasService.js
 import api from './api';
 
+export const generarAlertas = async () => {
+  await api.get('/alertas/generar');
+};
+
 export const obtenerAlertas = async () => {
   const response = await api.get('/alertas');
   return response.data;

--- a/server/init.sql
+++ b/server/init.sql
@@ -58,7 +58,13 @@ CREATE TABLE IF NOT EXISTS tipos_alerta (
   descripcion TEXT
 );
 
--- Tabla: alertas
+-- Asegurar que la tabla de alertas utilice equipo_id
+ALTER TABLE IF EXISTS alertas
+  ADD COLUMN IF NOT EXISTS equipo_id INTEGER REFERENCES equipos(id);
+
+ALTER TABLE IF EXISTS alertas
+  DROP COLUMN IF EXISTS orden_id;
+
 CREATE TABLE IF NOT EXISTS alertas (
   id SERIAL PRIMARY KEY,
   equipo_id INTEGER REFERENCES equipos(id),
@@ -67,6 +73,10 @@ CREATE TABLE IF NOT EXISTS alertas (
   leida BOOLEAN DEFAULT FALSE,
   generada_en TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
+
+CREATE UNIQUE INDEX IF NOT EXISTS alertas_equipo_tipo_unq
+  ON alertas (equipo_id, tipo_id)
+  WHERE leida = FALSE;
 
 -- Tabla: evidencias
 CREATE TABLE IF NOT EXISTS evidencias (


### PR DESCRIPTION
## Summary
- Trigger backend alert generation and cleanup whenever the alert page mounts
- Expose `generarAlertas` service and invoke it before fetching alert list
- Extend alert generation to handle pending and completed orders and delete resolved alerts

## Testing
- `cd server && npm test` *(fails: connect ECONNREFUSED ::1:5432)*
- `cd frontend && npm test` *(fails: No test files found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b76ee1bb44832ea1127aed334240ad