### PR TITLE
Add series and ingress date to equipment registration

### DIFF
--- a/frontend/src/pages/functions/Equipos.jsx
+++ b/frontend/src/pages/functions/Equipos.jsx
@@ -14,6 +14,7 @@ export default function Equipos() {
     familia: "",
     marca: "",
     modelo: "",
+    serie: "",
     criticidad: opcionesCriticidad[0],
     ubicacion: "",
     plan_id: ""
@@ -54,6 +55,7 @@ export default function Equipos() {
         familia: "",
         marca: "",
         modelo: "",
+        serie: "",
         criticidad: opcionesCriticidad[0],
         ubicacion: "",
         plan_id: ""
@@ -98,6 +100,18 @@ export default function Equipos() {
             type="text"
             name="modelo"
             value={form.modelo}
+            onChange={handleChange}
+            required
+            className="w-full border px-3 py-2 rounded"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium">Serie</label>
+          <input
+            type="text"
+            name="serie"
+            value={form.serie}
             onChange={handleChange}
             required
             className="w-full border px-3 py-2 rounded"

--- a/frontend/src/pages/functions/ListaEquipos.jsx
+++ b/frontend/src/pages/functions/ListaEquipos.jsx
@@ -26,8 +26,10 @@ export default function Visualizar() {
               <th className="border px-3 py-2">Familia</th>
               <th className="border px-3 py-2">Marca</th>
               <th className="border px-3 py-2">Modelo</th>
+              <th className="border px-3 py-2">Serie</th>
               <th className="border px-3 py-2">Ubicación</th>
               <th className="border px-3 py-2">Criticidad</th>
+              <th className="border px-3 py-2">Fecha ingreso</th>
               <th className="border px-3 py-2">Plan</th>
             </tr>
           </thead>
@@ -39,8 +41,10 @@ export default function Visualizar() {
                 <td className="border px-3 py-1">{equipo.familia}</td>
                 <td className="border px-3 py-1">{equipo.marca}</td>
                 <td className="border px-3 py-1">{equipo.modelo}</td>
+                <td className="border px-3 py-1">{equipo.serie}</td>
                 <td className="border px-3 py-1">{equipo.ubicacion}</td>
                 <td className="border px-3 py-1">{equipo.criticidad}</td>
+                <td className="border px-3 py-1">{equipo.fecha_ingreso}</td>
                 <td className="border px-3 py-1">{equipo.nombre_plan || "Sin plan"}</td>
               </tr>
             ))}

--- a/server/routes/equiposRoutes.js
+++ b/server/routes/equiposRoutes.js
@@ -7,11 +7,12 @@ router.post('/', async (req, res) => {
   const nombre = `${familia} ${marca} ${modelo}`;
 
   try {
-    const result = await db.query(`
-      INSERT INTO equipos (nombre, familia, criticidad, ubicacion, marca, modelo, serie, plan_id)
-      VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-      RETURNING *`,
-      [nombre, familia, criticidad, ubicacion, marca, modelo, serie, plan_id]);
+    const result = await db.query(
+      `INSERT INTO equipos (nombre, familia, criticidad, ubicacion, marca, modelo, serie, fecha_ingreso, plan_id)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, CURRENT_DATE, $8)
+       RETURNING *`,
+      [nombre, familia, criticidad, ubicacion, marca, modelo, serie, plan_id]
+    );
 
     res.status(201).json(result.rows[0]);
   } catch (err) {


### PR DESCRIPTION
## Summary
- capture equipment serial number in registration form
- store registration date automatically when creating an equipment
- display serial and entry date in equipment list

## Testing
- `npm test` (server) *(fails: Route.post() requires a callback function)*
- `npm test` (frontend) *(fails: missing dependency 'jsdom')*


------
https://chatgpt.com/codex/tasks/task_e_68bf96146e5c832eb6d0b1d366de2690