### PR TITLE
Capture equipment serial and entry date

### DIFF
--- a/frontend/src/pages/functions/Equipos.jsx
+++ b/frontend/src/pages/functions/Equipos.jsx
@@ -33,7 +33,6 @@ export default function Equipos() {
     ubicacion: "",
     plan_id: "",
     serie: "",
-    fecha_ingreso: "",
   });
 
   const [planes, setPlanes] = useState([]);
@@ -159,6 +158,21 @@ export default function Equipos() {
                 type="text"
                 name="modelo"
                 value={form.modelo}
+                onChange={handleChange}
+                required
+                className="pl-10 w-full border border-gray-300 rounded-lg px-3 py-2 text-sm outline-none"
+              />
+            </div>
+          </div>
+
+          <div className="flex flex-col">
+            <label className="text-sm text-gray-700 mb-1">Serie</label>
+            <div className="relative">
+              <ShieldCheck className="absolute left-3 top-2.5 text-gray-400" size={16} />
+              <input
+                type="text"
+                name="serie"
+                value={form.serie}
                 onChange={handleChange}
                 required
                 className="pl-10 w-full border border-gray-300 rounded-lg px-3 py-2 text-sm outline-none"

--- a/server/controllers/equiposController.js
+++ b/server/controllers/equiposController.js
@@ -5,6 +5,7 @@ const db = require("../db");
 exports.registrarEquipo = async (req, res) => {
   const { familia, criticidad, ubicacion, marca, modelo, serie, plan_id } = req.body;
   const nombre = `${familia} ${marca} ${modelo}`;
+  const fecha_ingreso = new Date().toISOString().split("T")[0];
 
   try {
     const existe = await db.query(`
@@ -17,10 +18,10 @@ exports.registrarEquipo = async (req, res) => {
     }
 
     const result = await db.query(`
-      INSERT INTO equipos (nombre, familia, criticidad, ubicacion, marca, modelo, serie, plan_id)
-      VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+      INSERT INTO equipos (nombre, familia, criticidad, ubicacion, marca, modelo, serie, fecha_ingreso, plan_id)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
       RETURNING *`,
-      [nombre, familia, criticidad, ubicacion, marca, modelo, serie, plan_id]);
+      [nombre, familia, criticidad, ubicacion, marca, modelo, serie, fecha_ingreso, plan_id]);
 
     return res.status(201).json(result.rows[0]);
   } catch (err) {

--- a/server/init.sql
+++ b/server/init.sql
@@ -34,7 +34,7 @@ CREATE TABLE IF NOT EXISTS equipos (
   marca VARCHAR(50),
   modelo VARCHAR(50),
   serie VARCHAR(50) UNIQUE,
-  fecha_ingreso DATE,
+  fecha_ingreso DATE DEFAULT CURRENT_DATE,
   fuente_plan VARCHAR(20) NOT NULL CHECK (fuente_plan IN ('garantia', 'contrato', 'interno')),
   plan_id INTEGER REFERENCES planes_mantenimiento(id)
 );


### PR DESCRIPTION
## Summary
- require serial number when registering equipment and auto-generate entry date
- store entry date in database with default to current date

## Testing
- `npm test` (server) *(fails: connect ECONNREFUSED ::1:5432)*
- `npm test` (frontend) *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf99f3e2f8832ea2c4a17b3f6c8103