### PR TITLE
feat: separate maintenance comments

### DIFF
--- a/frontend/src/components/calendar/EventModal.jsx
+++ b/frontend/src/components/calendar/EventModal.jsx
@@ -188,6 +188,7 @@ export default function EventModal({ evento, onClose }) {
           ordenCodigo={evento.id}
           equipoNombre={evento.title}
           equipoUbicacion={evento.ubicacion}
+          observacionesPrevias={evento.observaciones}
           onClose={() => setMostrarEjecutar(false)}
           onSuccess={() => {
             setMostrarEjecutar(false);

--- a/frontend/src/components/ordenes/ModalEjecutarOrden.jsx
+++ b/frontend/src/components/ordenes/ModalEjecutarOrden.jsx
@@ -1,5 +1,5 @@
 // src/components/ordenes/ModalEjecutarOrden.jsx
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Tag, MapPin, SquarePlus } from "lucide-react";
 import axios from "axios";
 
@@ -8,14 +8,22 @@ export default function ModalEjecutarOrden({
   equipoNombre,
   equipoUbicacion,
   ordenCodigo,
+  observacionesPrevias = {},
   onClose,
   onSuccess
 }) {
-  const [tareas, setTareas] = useState("");
-  const [observaciones, setObservaciones] = useState("");
+  const [tareas, setTareas] = useState(observacionesPrevias.tareas || "");
+  const [observaciones, setObservaciones] = useState(
+    observacionesPrevias.observaciones || ""
+  );
   const [archivos, setArchivos] = useState([]);
   const [subiendo, setSubiendo] = useState(false);
   const [error, setError] = useState(null);
+
+  useEffect(() => {
+    setTareas(observacionesPrevias?.tareas || "");
+    setObservaciones(observacionesPrevias?.observaciones || "");
+  }, [observacionesPrevias]);
 
   const handleArchivoChange = (e) => {
     setArchivos(Array.from(e.target.files));
@@ -43,12 +51,9 @@ export default function ModalEjecutarOrden({
         });
       }
 
-      // Unir tareas y observaciones
-      const comentarioCompleto = `Tareas realizadas:\n${tareas}\n\nObservaciones:\n${observaciones}`;
-
       await axios.put(
         `${import.meta.env.VITE_API_URL}/ordenes/${ordenId}/ejecutar`,
-        { observaciones: comentarioCompleto },
+        { observaciones: { tareas, observaciones } },
         {
           headers: { Authorization: `Bearer ${token}` },
         }

--- a/frontend/src/pages/functions/Calendario.jsx
+++ b/frontend/src/pages/functions/Calendario.jsx
@@ -35,7 +35,8 @@ export default function Calendario() {
         plan: evento.plan || "-",
         ubicacion: evento.ubicacion || "-",
         responsable: evento.responsable || null,
-        equipo_id: evento.equipo_id
+        equipo_id: evento.equipo_id,
+        observaciones: evento.observaciones || null
       }));
 
       setEventos(eventosConvertidos);

--- a/frontend/src/pages/functions/Reportes.jsx
+++ b/frontend/src/pages/functions/Reportes.jsx
@@ -101,6 +101,7 @@ export default function Reportes() {
           ordenCodigo={ordenSeleccionada.id}
           equipoNombre={ordenSeleccionada.equipo_nombre}
           equipoUbicacion={ordenSeleccionada.ubicacion}
+          observacionesPrevias={ordenSeleccionada.observaciones}
           onClose={() => setOrdenSeleccionada(null)}
           onSuccess={fetchOrdenes}
         />

--- a/server/init.sql
+++ b/server/init.sql
@@ -48,7 +48,7 @@ CREATE TABLE IF NOT EXISTS ordenes_trabajo (
   fecha_ejecucion DATE,
   responsable VARCHAR(100),
   estado VARCHAR(20) DEFAULT 'pendiente' CHECK (estado IN ('pendiente', 'realizada', 'reprogramada', 'omitida')),
-  observaciones TEXT
+  observaciones JSONB
 );
 
 -- Tabla: tipos_alerta

--- a/server/utils/generarReportes.js
+++ b/server/utils/generarReportes.js
@@ -39,14 +39,33 @@ async function generarReportePDF(orden, firmaTecnicoPath, firmaServicioPath, nom
       .text(orden.estado, 150, infoTop + 80);
     doc.moveTo(50, doc.y + 10).lineTo(550, doc.y + 10).stroke();
 
-    // Observaciones
+    // Observaciones, tareas y comentarios del supervisor
     if (orden.observaciones) {
-      doc
-        .moveDown()
-        .font('Helvetica')
-        .text('Observaciones:')
-        .font('Helvetica-Oblique')
-        .text(orden.observaciones, { width: 500 });
+      const { observaciones, tareas, comentarios_supervisor } = orden.observaciones;
+      if (tareas) {
+        doc
+          .moveDown()
+          .font('Helvetica')
+          .text('Tareas realizadas:')
+          .font('Helvetica-Oblique')
+          .text(tareas, { width: 500 });
+      }
+      if (observaciones) {
+        doc
+          .moveDown()
+          .font('Helvetica')
+          .text('Observaciones:')
+          .font('Helvetica-Oblique')
+          .text(observaciones, { width: 500 });
+      }
+      if (comentarios_supervisor) {
+        doc
+          .moveDown()
+          .font('Helvetica')
+          .text('Comentarios del supervisor:')
+          .font('Helvetica-Oblique')
+          .text(comentarios_supervisor, { width: 500 });
+      }
     }
     doc.moveTo(50, doc.y + 10).lineTo(550, doc.y + 10).stroke();
 


### PR DESCRIPTION
## Summary
- store work order notes as JSON to split tasks, observations, and supervisor comments
- handle JSON notes when executing and validating work orders
- render each note section in generated PDFs and send structured data from the client
- ensure technician notes persist after rejection and pre-fill execution modal

## Testing
- `npm test` *(server)* (fails: connect ECONNREFUSED ::1:5432)
- `npm test` *(frontend)* (fails: No test files found, exiting with code 1)


------
https://chatgpt.com/codex/tasks/task_e_68bf9a092b80832ea772c94dfde9901d