### PR TITLE
feat: detalle de ordenes y alerta al guardar firmas

### DIFF
--- a/frontend/src/pages/functions/RegistrosFirmas.jsx
+++ b/frontend/src/pages/functions/RegistrosFirmas.jsx
@@ -2,7 +2,7 @@
 import { useEffect, useState } from "react";
 import { getOrdenesValidadas, generarPDF, descargarReportePDF } from "../../services/reportesService";
 import FirmaDibujo from "../../components/FirmaDibujo";
-import { Download } from "lucide-react";
+import { Download, XCircle } from "lucide-react";
 import SuccessBanner from "../../components/SuccesBanner";
 import ErrorBanner from "../../components/ErrorBanner";
 
@@ -12,11 +12,27 @@ const formatearOT = (id) => `OT${String(id).padStart(4, "0")}`;
 export default function RegistrosYFirmas() {
   const [ordenes, setOrdenes] = useState([]);
   const [ordenSeleccionada, setOrdenSeleccionada] = useState(null);
+  const [ordenDetalle, setOrdenDetalle] = useState(null);
   const [firmaServicio, setFirmaServicio] = useState(null);
   const [firmaTecnico, setFirmaTecnico] = useState(null);
   const [generando, setGenerando] = useState(false);
   const [archivoGenerado, setArchivoGenerado] = useState(null);
   const [mensaje, setMensaje] = useState(null);
+
+  const extraerDetalle = (texto = "") => {
+    if (typeof texto !== "string") {
+      return {
+        tareas: "Sin tareas registradas.",
+        observaciones: "Sin observaciones.",
+      };
+    }
+    const tareasMatch = texto.match(/Tareas realizadas:\n([\s\S]*?)\n\nObservaciones:/);
+    const observacionesMatch = texto.match(/Observaciones:\n([\s\S]*)/);
+    return {
+      tareas: tareasMatch ? tareasMatch[1].trim() : "Sin tareas registradas.",
+      observaciones: observacionesMatch ? observacionesMatch[1].trim() : "Sin observaciones.",
+    };
+  };
 
   const fetchOrdenes = async () => {
     try {
@@ -48,10 +64,14 @@ export default function RegistrosYFirmas() {
   
       if (pdfRespuesta && pdfRespuesta.url) {
         setMensaje({ tipo: "success", texto: "Reporte generado correctamente." });
-  
+
         // Mostrar el PDF en nueva pestaña
         const baseUrl = import.meta.env.VITE_BACKEND_URL || "http://localhost:3000";
-        window.open(`${baseUrl}/uploads/${rutaFinal.replace(/^\/|^uploads\//, "")}`, "_blank");
+        const rutaFinal = pdfRespuesta.url;
+        window.open(
+          `${baseUrl}/uploads/${rutaFinal.replace(/^\/|^uploads\//, "")}`,
+          "_blank"
+        );
   
         // Limpiar estados
         setFirmaServicio(null);
@@ -78,6 +98,8 @@ export default function RegistrosYFirmas() {
     }
   };
 
+  const detalle = ordenDetalle ? extraerDetalle(ordenDetalle.observaciones || "") : null;
+
   return (
     <div className="p-6">
       {mensaje?.tipo === "success" && (
@@ -101,6 +123,7 @@ export default function RegistrosYFirmas() {
                 <th className="px-4 py-2">Equipo</th>
                 <th className="px-4 py-2">Ubicación</th>
                 <th className="px-4 py-2">Fecha</th>
+                <th className="px-4 py-2">Detalle</th>
               </tr>
             </thead>
             <tbody>
@@ -122,6 +145,17 @@ export default function RegistrosYFirmas() {
                   <td className="px-4 py-2">{orden.equipo_nombre}</td>
                   <td className="px-4 py-2">{orden.ubicacion}</td>
                   <td className="px-4 py-2">{new Date(orden.fecha_ejecucion).toLocaleDateString("es-CL")}</td>
+                  <td className="px-4 py-2 text-center">
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setOrdenDetalle(orden);
+                      }}
+                      className="text-blue-600 hover:underline"
+                    >
+                      Ver
+                    </button>
+                  </td>
                 </tr>
               ))}
             </tbody>
@@ -136,12 +170,22 @@ export default function RegistrosYFirmas() {
 
               <div className="mb-6">
                 <label className="block text-sm font-medium mb-1">Firma usuario servicio clínico</label>
-                <FirmaDibujo onSave={setFirmaServicio} />
+                <FirmaDibujo
+                  onSave={(data) => {
+                    setFirmaServicio(data);
+                    if (data) setMensaje({ tipo: "success", texto: "Firma guardada correctamente." });
+                  }}
+                />
               </div>
 
               <div className="mb-6">
                 <label className="block text-sm font-medium mb-1">Tu firma (técnico)</label>
-                <FirmaDibujo onSave={setFirmaTecnico} />
+                <FirmaDibujo
+                  onSave={(data) => {
+                    setFirmaTecnico(data);
+                    if (data) setMensaje({ tipo: "success", texto: "Firma guardada correctamente." });
+                  }}
+                />
               </div>
 
               <div className="flex justify-center gap-3">
@@ -169,6 +213,28 @@ export default function RegistrosYFirmas() {
           )}
         </div>
       </div>
+
+      {detalle && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-30">
+          <div className="bg-white rounded-3xl shadow-xl p-6 w-full max-w-md relative">
+            <button
+              className="absolute top-4 right-4 text-[#111A3A] hover:text-gray-600"
+              onClick={() => setOrdenDetalle(null)}
+            >
+              <XCircle size={20} />
+            </button>
+            <h2 className="text-lg font-bold text-[#111A3A] mb-4">Detalles de la orden</h2>
+            <div className="mb-4">
+              <h3 className="text-sm font-semibold text-gray-700 mb-1">Tareas realizadas</h3>
+              <p className="text-sm text-gray-600 whitespace-pre-line">{detalle.tareas}</p>
+            </div>
+            <div>
+              <h3 className="text-sm font-semibold text-gray-700 mb-1">Observaciones</h3>
+              <p className="text-sm text-gray-600 whitespace-pre-line">{detalle.observaciones}</p>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Mostrar banner con tareas y observaciones de cada orden validada
- Avisar con mensaje de éxito al guardar firmas en registro
- Evitar fallos al extraer tareas y observaciones cuando los datos no son texto

## Testing
- `npm test` *(fails: Cannot find dependency 'jsdom')*
- `npm install --save-dev jsdom` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bfa1838de4832e9fbe3b0dd919cb72