### PR TITLE
feat: mostrar identificadores en asignación de órdenes

### DIFF
--- a/frontend/src/pages/functions/AsignarOrden.jsx
+++ b/frontend/src/pages/functions/AsignarOrden.jsx
@@ -5,7 +5,7 @@ import SuccessBanner from "../../components/SuccesBanner";
 import ErrorBanner from "../../components/ErrorBanner";
 import MiniCalendar from "../../components/MiniCalendar";
 
-const formatearID = (id) => `ID${String(id).padStart(4, "0")}`;
+const formatearCodigo = (prefijo, id) => `${prefijo}${String(id).padStart(4, "0")}`;
 
 export default function AsignarOrdenes() {
   const [ordenes, setOrdenes] = useState([]);
@@ -138,7 +138,9 @@ export default function AsignarOrdenes() {
                   />
                 </th>
                 <th className="p-3">ID</th>
+                <th className="p-3">OT</th>
                 <th className="p-3">Equipo</th>
+                <th className="p-3">Serie</th>
                 <th className="p-3">Ubicación</th>
                 <th className="p-3">Fecha Programada</th>
               </tr>
@@ -153,8 +155,10 @@ export default function AsignarOrdenes() {
                       onChange={() => toggleSeleccion(orden.id)}
                     />
                   </td>
-                  <td className="p-3 text-sm text-gray-800">{formatearID(orden.id)}</td>
+                  <td className="p-3 text-sm text-gray-800">{formatearCodigo("ID", orden.equipo_id)}</td>
+                  <td className="p-3 text-sm text-gray-800">{formatearCodigo("OT", orden.id)}</td>
                   <td className="p-3 text-sm text-gray-600">{orden.equipo_nombre}</td>
+                  <td className="p-3 text-sm text-gray-600">{orden.equipo_serie}</td>
                   <td className="p-3 text-sm text-gray-600">{orden.ubicacion}</td>
                   <td className="p-3 text-sm text-gray-600">{new Date(orden.fecha_programada).toLocaleDateString("es-CL")}</td>
                 </tr>

--- a/server/controllers/ordenesController.js
+++ b/server/controllers/ordenesController.js
@@ -344,7 +344,7 @@ async function obtenerOrdenesSinResponsable(req, res) {
 
     const { rows } = await db.query(
       `
-      SELECT o.*, e.nombre AS equipo_nombre, e.ubicacion
+      SELECT o.*, e.nombre AS equipo_nombre, e.ubicacion, e.serie AS equipo_serie
       FROM ordenes_trabajo o
       JOIN equipos e ON o.equipo_id = e.id
       WHERE o.estado = 'pendiente'


### PR DESCRIPTION
## Summary
- Mostrar identificador de equipo y de OT en la tabla de asignación de órdenes
- Incluir serie del equipo en los datos entregados por la API

## Testing
- `npm test` *(server) — failed: connect ECONNREFUSED 127.0.0.1:5432*
- `npm test` *(frontend) — failed: No test files found*

------
https://chatgpt.com/codex/tasks/task_e_68bfa682527c832e861f95c5ee2b2804