### PR TITLE
feat: mostrar identificadores en asignación, ejecución y validación

### DIFF
--- a/frontend/src/components/calendar/EventModal.jsx
+++ b/frontend/src/components/calendar/EventModal.jsx
@@ -185,7 +185,8 @@ export default function EventModal({ evento, onClose }) {
       {mostrarEjecutar && (
         <ModalEjecutarOrden
           ordenId={evento.id}
-          ordenCodigo={evento.id}
+          equipoId={evento.equipo_id}
+          equipoSerie={evento.serie}
           equipoNombre={evento.title}
           equipoUbicacion={evento.ubicacion}
           observacionesPrevias={evento.observaciones}

--- a/frontend/src/components/ordenes/ModalEjecutarOrden.jsx
+++ b/frontend/src/components/ordenes/ModalEjecutarOrden.jsx
@@ -5,9 +5,10 @@ import axios from "axios";
 
 export default function ModalEjecutarOrden({
   ordenId,
+  equipoId,
+  equipoSerie,
   equipoNombre,
   equipoUbicacion,
-  ordenCodigo,
   observacionesPrevias = {},
   onClose,
   onSuccess
@@ -70,7 +71,7 @@ export default function ModalEjecutarOrden({
     }
   };
 
-  const formatearID = (id) => `ID${String(id).padStart(4, "0")}`;
+  const formatearCodigo = (prefijo, id) => `${prefijo}${String(id).padStart(4, "0")}`;
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-40">
@@ -83,11 +84,19 @@ export default function ModalEjecutarOrden({
         <div className="flex flex-col gap-2 mb-6 mt-4">
           <div className="flex items-center gap-2 text-sm text-gray-700">
             <Tag className="w-4 h-4 text-[#111A3A]" />
-            <span><strong>ID:</strong> ID{String(ordenCodigo).padStart(4, "0")}</span>
+            <span><strong>ID:</strong> {formatearCodigo("ID", equipoId)}</span>
+          </div>
+          <div className="flex items-center gap-2 text-sm text-gray-700">
+            <Tag className="w-4 h-4 text-[#111A3A]" />
+            <span><strong>OT:</strong> {formatearCodigo("OT", ordenId)}</span>
           </div>
           <div className="flex items-center gap-2 text-sm text-gray-700">
             <SquarePlus className="w-4 h-4 text-[#111A3A]" />
             <span><strong>Equipo:</strong> {equipoNombre}</span>
+          </div>
+          <div className="flex items-center gap-2 text-sm text-gray-700">
+            <Tag className="w-4 h-4 text-[#111A3A]" />
+            <span><strong>Serie:</strong> {equipoSerie || "No especificada"}</span>
           </div>
           <div className="flex items-center gap-2 text-sm text-gray-700">
             <MapPin className="w-4 h-4 text-[#111A3A]" />

--- a/frontend/src/pages/functions/AsignarOrden.jsx
+++ b/frontend/src/pages/functions/AsignarOrden.jsx
@@ -5,7 +5,7 @@ import SuccessBanner from "../../components/SuccesBanner";
 import ErrorBanner from "../../components/ErrorBanner";
 import MiniCalendar from "../../components/MiniCalendar";
 
-const formatearID = (id) => `ID${String(id).padStart(4, "0")}`;
+const formatearCodigo = (prefijo, id) => `${prefijo}${String(id).padStart(4, "0")}`;
 
 export default function AsignarOrdenes() {
   const [ordenes, setOrdenes] = useState([]);
@@ -138,7 +138,9 @@ export default function AsignarOrdenes() {
                   />
                 </th>
                 <th className="p-3">ID</th>
+                <th className="p-3">OT</th>
                 <th className="p-3">Equipo</th>
+                <th className="p-3">Serie</th>
                 <th className="p-3">Ubicación</th>
                 <th className="p-3">Fecha Programada</th>
               </tr>
@@ -153,8 +155,10 @@ export default function AsignarOrdenes() {
                       onChange={() => toggleSeleccion(orden.id)}
                     />
                   </td>
-                  <td className="p-3 text-sm text-gray-800">{formatearID(orden.id)}</td>
+                  <td className="p-3 text-sm text-gray-800">{formatearCodigo("ID", orden.equipo_id)}</td>
+                  <td className="p-3 text-sm text-gray-800">{formatearCodigo("OT", orden.id)}</td>
                   <td className="p-3 text-sm text-gray-600">{orden.equipo_nombre}</td>
+                  <td className="p-3 text-sm text-gray-600">{orden.equipo_serie}</td>
                   <td className="p-3 text-sm text-gray-600">{orden.ubicacion}</td>
                   <td className="p-3 text-sm text-gray-600">{new Date(orden.fecha_programada).toLocaleDateString("es-CL")}</td>
                 </tr>

--- a/frontend/src/pages/functions/Reportes.jsx
+++ b/frontend/src/pages/functions/Reportes.jsx
@@ -5,6 +5,8 @@ import { getOrdenesPendientes } from "../../services/ordenesServices";
 import { Search } from "lucide-react";
 import MiniCalendar from "../../components/MiniCalendar";
 
+const formatearCodigo = (prefijo, id) => `${prefijo}${String(id).padStart(4, "0")}`;
+
 export default function Reportes() {
   const [ordenes, setOrdenes] = useState([]);
   const [ordenSeleccionada, setOrdenSeleccionada] = useState(null);
@@ -53,7 +55,9 @@ export default function Reportes() {
             <thead className="bg-gray-50">
               <tr className="text-left text-sm text-gray-600">
                 <th className="p-3">ID</th>
+                <th className="p-3">OT</th>
                 <th className="p-3">Equipo</th>
+                <th className="p-3">Serie</th>
                 <th className="p-3">Ubicación</th>
                 <th className="p-3">Fecha programada</th>
                 <th className="p-3">Responsable</th>
@@ -63,8 +67,10 @@ export default function Reportes() {
             <tbody>
               {ordenesFiltradas.map((orden) => (
                 <tr key={orden.id} className="border-t">
-                  <td className="p-3 text-sm text-gray-800">{`ID${String(orden.id).padStart(4, "0")}`}</td>
+                  <td className="p-3 text-sm text-gray-800">{formatearCodigo("ID", orden.equipo_id)}</td>
+                  <td className="p-3 text-sm text-gray-800">{formatearCodigo("OT", orden.id)}</td>
                   <td className="p-3 text-sm text-gray-600">{orden.equipo_nombre || "-"}</td>
+                  <td className="p-3 text-sm text-gray-600">{orden.equipo_serie || "-"}</td>
                   <td className="p-3 text-sm text-gray-600">{orden.ubicacion || "-"}</td>
                   <td className="p-3 text-sm text-gray-600">
                     {new Date(orden.fecha_programada).toLocaleDateString("es-CL")}
@@ -73,12 +79,12 @@ export default function Reportes() {
                     {orden?.responsable_nombre?.trim() || <span className="italic text-gray-400">Sin asignar</span>}
                   </td>
                   <td className="p-3 text-center">
-                  <button
-                    onClick={() => setOrdenSeleccionada(orden)}
-                    className="bg-[#D0FF34] text-[#111A3A] px-6 py-1 rounded shadow hover:bg-lime-300"
-                  >
-                    <span className="text-sm">Ejecutar Orden</span>
-                  </button>
+                    <button
+                      onClick={() => setOrdenSeleccionada(orden)}
+                      className="bg-[#D0FF34] text-[#111A3A] px-6 py-1 rounded shadow hover:bg-lime-300"
+                    >
+                      <span className="text-sm">Ejecutar Orden</span>
+                    </button>
                   </td>
                 </tr>
               ))}
@@ -98,7 +104,8 @@ export default function Reportes() {
       {ordenSeleccionada && (
         <ModalEjecutarOrden
           ordenId={ordenSeleccionada.id}
-          ordenCodigo={ordenSeleccionada.id}
+          equipoId={ordenSeleccionada.equipo_id}
+          equipoSerie={ordenSeleccionada.equipo_serie}
           equipoNombre={ordenSeleccionada.equipo_nombre}
           equipoUbicacion={ordenSeleccionada.ubicacion}
           observacionesPrevias={ordenSeleccionada.observaciones}

--- a/frontend/src/pages/functions/ValidarOrdenes.jsx
+++ b/frontend/src/pages/functions/ValidarOrdenes.jsx
@@ -6,7 +6,7 @@ import ErrorBanner from "../../components/ErrorBanner";
 import MiniCalendar from "../../components/MiniCalendar";
 import { getOrdenesEjecutadas, validarOrden } from "../../services/ordenesServices";
 
-const formatearID = (id) => `ID${String(id).padStart(4, "0")}`;
+const formatearCodigo = (prefijo, id) => `${prefijo}${String(id).padStart(4, "0")}`;
 
 export default function ValidarOrdenes() {
   const [ordenes, setOrdenes] = useState([]);
@@ -122,7 +122,9 @@ export default function ValidarOrdenes() {
                   />
                 </th>
                 <th className="p-3">ID</th>
+                <th className="p-3">OT</th>
                 <th className="p-3">Equipo</th>
+                <th className="p-3">Serie</th>
                 <th className="p-3">Ubicación</th>
                 <th className="p-3">Técnico</th>
                 <th className="p-3">Ejecución</th>
@@ -140,10 +142,16 @@ export default function ValidarOrdenes() {
                     />
                   </td>
                   <td className="p-3 text-sm text-gray-800">
-                    {formatearID(orden.id)}
+                    {formatearCodigo("ID", orden.equipo_id)}
+                  </td>
+                  <td className="p-3 text-sm text-gray-800">
+                    {formatearCodigo("OT", orden.id)}
                   </td>
                   <td className="p-3 text-sm text-gray-600">
                     {orden.equipo_nombre}
+                  </td>
+                  <td className="p-3 text-sm text-gray-600">
+                    {orden.equipo_serie}
                   </td>
                   <td className="p-3 text-sm text-gray-600">
                     {orden.ubicacion}

--- a/server/controllers/ordenesController.js
+++ b/server/controllers/ordenesController.js
@@ -312,7 +312,7 @@ const obtenerOrdenesPendientesAsignadas = async (req, res) => {
 
     const params = [hasta.toISOString().slice(0, 10)];
     let query = `
-      SELECT o.*, e.nombre AS equipo_nombre, e.ubicacion, u.nombre AS responsable_nombre
+      SELECT o.*, e.nombre AS equipo_nombre, e.ubicacion, e.serie AS equipo_serie, u.nombre AS responsable_nombre
       FROM ordenes_trabajo o
       JOIN equipos e ON o.equipo_id = e.id
       LEFT JOIN usuarios u ON o.responsable = CAST(u.id AS VARCHAR)
@@ -344,7 +344,7 @@ async function obtenerOrdenesSinResponsable(req, res) {
 
     const { rows } = await db.query(
       `
-      SELECT o.*, e.nombre AS equipo_nombre, e.ubicacion
+      SELECT o.*, e.nombre AS equipo_nombre, e.ubicacion, e.serie AS equipo_serie
       FROM ordenes_trabajo o
       JOIN equipos e ON o.equipo_id = e.id
       WHERE o.estado = 'pendiente'

--- a/server/models/ordenesModel.js
+++ b/server/models/ordenesModel.js
@@ -75,12 +75,13 @@ async function getOrdenDetallada(id) {
 // Obtener órdenes ejecutadas no validadas
 async function obtenerOrdenesEjecutadasNoValidadas() {
   const query = `
-    SELECT ot.*, 
-           e.nombre AS equipo_nombre, 
-           e.ubicacion, 
+    SELECT ot.*,
+           e.nombre AS equipo_nombre,
+           e.ubicacion,
+           e.serie AS equipo_serie,
            u.nombre AS tecnico_nombre,
            (
-             SELECT COUNT(*) 
+             SELECT COUNT(*)
              FROM evidencias ev
              WHERE ev.orden_id = ot.id
            ) AS total_evidencias


### PR DESCRIPTION
## Summary
- Incluir ID, OT y serie del equipo en la validación de órdenes
- Exponer serie del equipo en el listado de órdenes ejecutadas para validación

## Testing
- `npm test` *(server)* — failed: expected [400, 401] to include 500
- `npm test` *(frontend)* — failed: MISSING DEPENDENCY  Cannot find dependency 'jsdom'


------
https://chatgpt.com/codex/tasks/task_e_68bfa682527c832e861f95c5ee2b2804