### PR TITLE
fix: handle null previous observations in execution modal

### DIFF
--- a/frontend/src/components/ordenes/ModalEjecutarOrden.jsx
+++ b/frontend/src/components/ordenes/ModalEjecutarOrden.jsx
@@ -9,13 +9,13 @@ export default function ModalEjecutarOrden({
   equipoSerie,
   equipoNombre,
   equipoUbicacion,
-  observacionesPrevias = {},
+  observacionesPrevias,
   onClose,
   onSuccess
 }) {
-  const [tareas, setTareas] = useState(observacionesPrevias.tareas || "");
+  const [tareas, setTareas] = useState(observacionesPrevias?.tareas || "");
   const [observaciones, setObservaciones] = useState(
-    observacionesPrevias.observaciones || ""
+    observacionesPrevias?.observaciones || ""
   );
   const [archivos, setArchivos] = useState([]);
   const [subiendo, setSubiendo] = useState(false);


### PR DESCRIPTION
## Summary
- avoid reading tareas/observaciones when `observacionesPrevias` is null

## Testing
- `npm test` *(fails: Cannot find dependency 'jsdom')*
- `npm install jsdom` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jsdom)*

------
https://chatgpt.com/codex/tasks/task_e_68bfac79e390832eb532c08ad792682b