### PR TITLE
fix: cast supervisor comment to text

### DIFF
--- a/server/models/ordenesModel.js
+++ b/server/models/ordenesModel.js
@@ -104,7 +104,9 @@ async function validarOrdenTrabajo(id, validada, comentario, supervisor_id) {
     `
     UPDATE ordenes_trabajo
     SET estado = $1,
-        observaciones = COALESCE(observaciones, '{}'::jsonb) || jsonb_build_object('comentarios_supervisor', $2)
+        observaciones =
+          COALESCE(observaciones, '{}'::jsonb) ||
+          jsonb_build_object('comentarios_supervisor', $2::text)
     WHERE id = $3
     RETURNING *
   `,


### PR DESCRIPTION
## Summary
- ensure supervisor comments are cast to text in order validation query

## Testing
- `npm test` (fails: connect ECONNREFUSED 127.0.0.1:5432)

------
https://chatgpt.com/codex/tasks/task_e_68bfabda6458832e86117516d5033678