### PR TITLE
Recargar equipos pendientes tras planificar

### DIFF
--- a/frontend/src/pages/functions/GestionPlanificacion.jsx
+++ b/frontend/src/pages/functions/GestionPlanificacion.jsx
@@ -33,7 +33,7 @@ export default function GestionPlanificacion() {
     }
   }, [navigate, user]);
 
-  useEffect(() => {
+  const cargarEquipos = () => {
     axios
       .get(`${import.meta.env.VITE_API_URL}/ordenes/faltantes`)
       .then((res) => {
@@ -43,6 +43,10 @@ export default function GestionPlanificacion() {
         console.error("Error al cargar equipos sin orden:", err);
         setMensaje({ tipo: "error", texto: "Error al cargar equipos." });
       });
+  };
+
+  useEffect(() => {
+    cargarEquipos();
   }, []);
 
   useEffect(() => {
@@ -95,6 +99,7 @@ export default function GestionPlanificacion() {
       setMensaje({ tipo: "success", texto: "Mantenimientos programados con éxito." });
       setSeleccionados([]);
       setFecha("");
+      cargarEquipos();
     } catch (err) {
       console.error("Error al programar:", err);
       setMensaje({ tipo: "error", texto: "Error al programar mantenimientos." });


### PR DESCRIPTION
## Summary
- Refetch pending-equipment list after saving maintenance planning

## Testing
- `npm test` *(fails: Cannot find dependency 'jsdom'; No test files)*
- `npm install jsdom --no-save` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jsdom)*

------
https://chatgpt.com/codex/tasks/task_e_68bfaeaa03bc832e99bc9bfe607eb1e5