### PR TITLE
feat: add maintenance detail modal

### DIFF
--- a/frontend/src/components/ordenes/DetalleOrdenModal.jsx
+++ b/frontend/src/components/ordenes/DetalleOrdenModal.jsx
@@ -1,0 +1,57 @@
+// src/components/ordenes/DetalleOrdenModal.jsx
+import { XCircle } from "lucide-react";
+
+export default function DetalleOrdenModal({ orden, evidencias = [], onClose }) {
+  if (!orden) return null;
+  const baseUrl = import.meta.env.VITE_API_URL;
+  const observacion = orden.observaciones?.observaciones || "Sin observaciones";
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-30 z-50 flex justify-center items-center">
+      <div className="bg-white rounded-3xl shadow-xl p-6 w-full max-w-md relative">
+        <button
+          className="absolute top-4 right-4 text-[#111A3A] hover:text-gray-600"
+          onClick={onClose}
+        >
+          <XCircle size={20} />
+        </button>
+
+        <h2 className="text-lg font-bold text-[#111A3A] mb-4">Detalle de la OT</h2>
+
+        <div className="space-y-4 text-sm text-gray-700">
+          <div>
+            <h3 className="font-semibold text-[#111A3A] mb-1">Observaciones</h3>
+            <p className="whitespace-pre-line">{observacion}</p>
+          </div>
+
+          <div>
+            <h3 className="font-semibold text-[#111A3A] mb-1">Evidencias</h3>
+            {evidencias.length > 0 ? (
+              <div className="flex flex-wrap gap-2">
+                {evidencias.map((ev, idx) => {
+                  const yaTieneCarpeta =
+                    ev.url?.includes("reportes/") || ev.url?.includes("evidencias/");
+                  const carpeta = ev.tipo === "reporte_firmado" ? "reportes" : "evidencias";
+                  const rutaFinal = yaTieneCarpeta ? ev.url : `${carpeta}/${ev.url}`;
+                  return (
+                    <a
+                      key={idx}
+                      href={`${baseUrl}/uploads/${rutaFinal.replace(/^\\/|^uploads\\//, "")}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="bg-[#D0FF34] text-[#111A3A] px-4 py-1 rounded-full text-xs font-semibold hover:bg-lime-300"
+                    >
+                      {ev.etiqueta || `Evidencia ${idx + 1}`}
+                    </a>
+                  );
+                })}
+              </div>
+            ) : (
+              <p className="text-gray-500">Sin evidencias</p>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/functions/ValidarOrdenes.jsx
+++ b/frontend/src/pages/functions/ValidarOrdenes.jsx
@@ -5,6 +5,8 @@ import SuccessBanner from "../../components/SuccesBanner";
 import ErrorBanner from "../../components/ErrorBanner";
 import MiniCalendar from "../../components/MiniCalendar";
 import { getOrdenesEjecutadas, validarOrden } from "../../services/ordenesServices";
+import { getEvidenciasPorOrden } from "../../services/evidenciasService";
+import DetalleOrdenModal from "../../components/ordenes/DetalleOrdenModal";
 
 const formatearCodigo = (prefijo, id) => `${prefijo}${String(id).padStart(4, "0")}`;
 
@@ -14,6 +16,8 @@ export default function ValidarOrdenes() {
   const [comentario, setComentario] = useState("");
   const [busqueda, setBusqueda] = useState("");
   const [mensaje, setMensaje] = useState(null);
+  const [ordenDetalle, setOrdenDetalle] = useState(null);
+  const [evidencias, setEvidencias] = useState([]);
 
   const fetchOrdenes = async () => {
     try {
@@ -41,6 +45,17 @@ export default function ValidarOrdenes() {
       setSeleccionados([]);
     } else {
       setSeleccionados(filtradas.map((o) => o.id));
+    }
+  };
+
+  const verDetalle = async (orden) => {
+    setOrdenDetalle(orden);
+    try {
+      const data = await getEvidenciasPorOrden(orden.id);
+      setEvidencias(data);
+    } catch (error) {
+      console.error("Error al obtener evidencias:", error);
+      setEvidencias([]);
     }
   };
 
@@ -74,7 +89,8 @@ export default function ValidarOrdenes() {
   );
 
   return (
-    <div className="p-6">
+    <>
+      <div className="p-6">
       {mensaje?.tipo === "success" && (
         <SuccessBanner
           title="Éxito"
@@ -164,6 +180,12 @@ export default function ValidarOrdenes() {
                   </td>
                   <td className="p-3 text-sm text-gray-600">
                     {orden.total_evidencias} archivo(s)
+                    <button
+                      onClick={() => verDetalle(orden)}
+                      className="ml-2 bg-[#D0FF34] text-[#111A3A] font-semibold text-xs px-2 py-1 rounded shadow hover:bg-lime-300"
+                    >
+                      Ver
+                    </button>
                   </td>
                 </tr>
               ))}
@@ -205,6 +227,13 @@ export default function ValidarOrdenes() {
           </button>
         </div>
       </div>
-    </div>
+      {ordenDetalle && (
+        <DetalleOrdenModal
+          orden={ordenDetalle}
+          evidencias={evidencias}
+          onClose={() => setOrdenDetalle(null)}
+        />
+      )}
+    </>
   );
 }

--- a/frontend/src/services/evidenciasService.js
+++ b/frontend/src/services/evidenciasService.js
@@ -1,0 +1,8 @@
+// src/services/evidenciasService.js
+import api from './api';
+
+export const getEvidenciasPorOrden = async (ordenId) => {
+  const response = await api.get(`/evidencias/${ordenId}`);
+  return response.data;
+};
+

--- a/server/routes/evidenciasRoutes.js
+++ b/server/routes/evidenciasRoutes.js
@@ -3,7 +3,7 @@ const express = require('express');
 const router = express.Router();
 const multer = require('multer');
 const path = require('path');
-const { subirEvidencia } = require('../controllers/evidenciasController');
+const { subirEvidencia, listarEvidencias } = require('../controllers/evidenciasController');
 const { verifyToken } = require('../middlewares/auth');
 
 // Carpeta de destino
@@ -40,5 +40,8 @@ router.post('/', verifyToken, upload.single('archivo'), subirEvidencia);
 // Ruta para descargar reportes PDF
 const { descargarPDF } = require('../controllers/reportesController');
 router.get('/descargar/:nombreArchivo', verifyToken, descargarPDF);
+
+// Listar evidencias de una orden
+router.get('/:ordenId', verifyToken, listarEvidencias);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- allow supervisors to view order details with observations and evidences
- add service and modal for evidence preview
- expose API route to list evidences for a work order
- fix JSX structure on validation page to handle conditional modal rendering

## Testing
- `npm test` (server) *(fails: connect ECONNREFUSED ::1:5432)*
- `npm test` (frontend) *(fails: Cannot find dependency 'jsdom')*
- `npx vite build` *(fails: Cannot find module '@tailwindcss/line-clamp')*

------
https://chatgpt.com/codex/tasks/task_e_68bfaf891fec832ea0588cec5714d7aa