### PR TITLE
Log audit events for order execution and signing

### DIFF
--- a/server/controllers/ordenesController.js
+++ b/server/controllers/ordenesController.js
@@ -251,6 +251,13 @@ async function ejecutarOrden(req, res) {
       [ordenId, JSON.stringify(observaciones || {})]
     );
 
+    await crearLog({
+      usuario_id: 2,
+      accion: 'ejecutar_orden',
+      tabla: 'ordenes_trabajo',
+      registro_id: ordenId
+    });
+
     const frecuenciaResult = await db.query(`
       SELECT frecuencia FROM planes_mantenimiento WHERE id = $1
     `, [plan_id]);
@@ -527,6 +534,13 @@ const generarPDF = async (req, res) => {
       `UPDATE ordenes_trabajo SET estado = 'firmada' WHERE id = $1`,
       [ordenId]
     );
+
+    await crearLog({
+      usuario_id: 2,
+      accion: 'firmar_orden',
+      tabla: 'ordenes_trabajo',
+      registro_id: ordenId
+    });
 
     // 📁 Guardar evidencia en la base de datos
     await db.query(`


### PR DESCRIPTION
## Summary
- Log order execution in audit log
- Log order signature in audit log

## Testing
- `npm test --prefix server` *(fails: connect ECONNREFUSED ::1:5432, Error en login local)*

------
https://chatgpt.com/codex/tasks/task_e_68bfb22441cc832ea1aa7f68ccdccc1a