### PR TITLE
Mostrar tareas y observaciones de OT

### DIFF
--- a/frontend/src/components/ordenes/DetalleOrdenModal.jsx
+++ b/frontend/src/components/ordenes/DetalleOrdenModal.jsx
@@ -4,6 +4,7 @@ import { XCircle } from "lucide-react";
 export default function DetalleOrdenModal({ orden, evidencias = [], onClose }) {
   if (!orden) return null;
   const baseUrl = import.meta.env.VITE_BACKEND_URL || "http://localhost:3000";
+  const tareas = orden.observaciones?.tareas || "Sin tareas registradas";
   const observacion = orden.observaciones?.observaciones || "Sin observaciones";
 
   return (
@@ -19,6 +20,10 @@ export default function DetalleOrdenModal({ orden, evidencias = [], onClose }) {
         <h2 className="text-lg font-bold text-[#111A3A] mb-4">Detalle de la OT</h2>
 
         <div className="space-y-4 text-sm text-gray-700">
+          <div>
+            <h3 className="font-semibold text-[#111A3A] mb-1">Tareas realizadas</h3>
+            <p className="whitespace-pre-line">{tareas}</p>
+          </div>
           <div>
             <h3 className="font-semibold text-[#111A3A] mb-1">Observaciones</h3>
             <p className="whitespace-pre-line">{observacion}</p>

--- a/frontend/src/pages/functions/RegistrosFirmas.jsx
+++ b/frontend/src/pages/functions/RegistrosFirmas.jsx
@@ -19,15 +19,23 @@ export default function RegistrosYFirmas() {
   const [archivoGenerado, setArchivoGenerado] = useState(null);
   const [mensaje, setMensaje] = useState(null);
 
-  const extraerDetalle = (texto = "") => {
-    if (typeof texto !== "string") {
+  const extraerDetalle = (obs) => {
+    if (!obs) {
       return {
         tareas: "Sin tareas registradas.",
         observaciones: "Sin observaciones.",
       };
     }
-    const tareasMatch = texto.match(/Tareas realizadas:\n([\s\S]*?)\n\nObservaciones:/);
-    const observacionesMatch = texto.match(/Observaciones:\n([\s\S]*)/);
+
+    if (typeof obs === "object") {
+      return {
+        tareas: obs.tareas?.trim() || "Sin tareas registradas.",
+        observaciones: obs.observaciones?.trim() || "Sin observaciones.",
+      };
+    }
+
+    const tareasMatch = obs.match(/Tareas realizadas:\n([\s\S]*?)\n\nObservaciones:/);
+    const observacionesMatch = obs.match(/Observaciones:\n([\s\S]*)/);
     return {
       tareas: tareasMatch ? tareasMatch[1].trim() : "Sin tareas registradas.",
       observaciones: observacionesMatch ? observacionesMatch[1].trim() : "Sin observaciones.",
@@ -98,7 +106,7 @@ export default function RegistrosYFirmas() {
     }
   };
 
-  const detalle = ordenDetalle ? extraerDetalle(ordenDetalle.observaciones || "") : null;
+  const detalle = ordenDetalle ? extraerDetalle(ordenDetalle.observaciones) : null;
 
   return (
     <div className="p-6">


### PR DESCRIPTION
## Summary
- Muestra las tareas y observaciones registradas en la OT dentro del módulo de Registros y Firmas
- Incluye las tareas realizadas en el modal de detalle utilizado al validar mantenimientos

## Testing
- `npm test` *(frontend: falta dependencia jsdom)*
- `npm test` *(server: conexión a base de datos rechazada)*

------
https://chatgpt.com/codex/tasks/task_e_68bfb7549a9c832eb009c42033317d83