### PR TITLE
Mostrar tareas y observaciones de OT

### DIFF
--- a/frontend/src/components/ordenes/DetalleOrdenModal.jsx
+++ b/frontend/src/components/ordenes/DetalleOrdenModal.jsx
@@ -4,7 +4,35 @@ import { XCircle } from "lucide-react";
 export default function DetalleOrdenModal({ orden, evidencias = [], onClose }) {
   if (!orden) return null;
   const baseUrl = import.meta.env.VITE_BACKEND_URL || "http://localhost:3000";
-  const observacion = orden.observaciones?.observaciones || "Sin observaciones";
+
+  const limpiarTexto = (valor, defecto) => {
+    if (!valor) return defecto;
+    if (Array.isArray(valor)) {
+      const texto = valor
+        .map((v) => (typeof v === "string" ? v : v?.descripcion || v?.tarea || ""))
+        .filter(Boolean)
+        .join("\n")
+        .trim();
+      return texto || defecto;
+    }
+    return String(valor).trim() || defecto;
+  };
+
+  let tareas = "Sin tareas registradas";
+  let observacion = "Sin observaciones";
+  const obs = orden.observaciones;
+
+  if (obs) {
+    if (typeof obs === "object") {
+      tareas = limpiarTexto(obs.tareas, tareas);
+      observacion = limpiarTexto(obs.observaciones, observacion);
+    } else {
+      const tareasMatch = obs.match(/Tareas realizadas:\n([\s\S]*?)\n\nObservaciones:/);
+      const observacionesMatch = obs.match(/Observaciones:\n([\s\S]*)/);
+      if (tareasMatch) tareas = tareasMatch[1].trim();
+      if (observacionesMatch) observacion = observacionesMatch[1].trim();
+    }
+  }
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-30 z-50 flex justify-center items-center">
@@ -19,6 +47,10 @@ export default function DetalleOrdenModal({ orden, evidencias = [], onClose }) {
         <h2 className="text-lg font-bold text-[#111A3A] mb-4">Detalle de la OT</h2>
 
         <div className="space-y-4 text-sm text-gray-700">
+          <div>
+            <h3 className="font-semibold text-[#111A3A] mb-1">Tareas realizadas</h3>
+            <p className="whitespace-pre-line">{tareas}</p>
+          </div>
           <div>
             <h3 className="font-semibold text-[#111A3A] mb-1">Observaciones</h3>
             <p className="whitespace-pre-line">{observacion}</p>

--- a/frontend/src/pages/functions/RegistrosFirmas.jsx
+++ b/frontend/src/pages/functions/RegistrosFirmas.jsx
@@ -19,15 +19,36 @@ export default function RegistrosYFirmas() {
   const [archivoGenerado, setArchivoGenerado] = useState(null);
   const [mensaje, setMensaje] = useState(null);
 
-  const extraerDetalle = (texto = "") => {
-    if (typeof texto !== "string") {
+  const extraerDetalle = (obs) => {
+    const limpiarTexto = (valor, defecto) => {
+      if (!valor) return defecto;
+      if (Array.isArray(valor)) {
+        const texto = valor
+          .map((v) => (typeof v === "string" ? v : v?.descripcion || v?.tarea || ""))
+          .filter(Boolean)
+          .join("\n")
+          .trim();
+        return texto || defecto;
+      }
+      return String(valor).trim() || defecto;
+    };
+
+    if (!obs) {
       return {
         tareas: "Sin tareas registradas.",
         observaciones: "Sin observaciones.",
       };
     }
-    const tareasMatch = texto.match(/Tareas realizadas:\n([\s\S]*?)\n\nObservaciones:/);
-    const observacionesMatch = texto.match(/Observaciones:\n([\s\S]*)/);
+
+    if (typeof obs === "object") {
+      return {
+        tareas: limpiarTexto(obs.tareas, "Sin tareas registradas."),
+        observaciones: limpiarTexto(obs.observaciones, "Sin observaciones."),
+      };
+    }
+
+    const tareasMatch = obs.match(/Tareas realizadas:\n([\s\S]*?)\n\nObservaciones:/);
+    const observacionesMatch = obs.match(/Observaciones:\n([\s\S]*)/);
     return {
       tareas: tareasMatch ? tareasMatch[1].trim() : "Sin tareas registradas.",
       observaciones: observacionesMatch ? observacionesMatch[1].trim() : "Sin observaciones.",
@@ -98,7 +119,7 @@ export default function RegistrosYFirmas() {
     }
   };
 
-  const detalle = ordenDetalle ? extraerDetalle(ordenDetalle.observaciones || "") : null;
+  const detalle = ordenDetalle ? extraerDetalle(ordenDetalle.observaciones) : null;
 
   return (
     <div className="p-6">


### PR DESCRIPTION
## Summary
- Normaliza tareas y observaciones para admitir arreglos, objetos o cadenas sin errores al ver detalles de la OT
- Ajusta el modal de detalle de OT para interpretar distintos formatos de tareas y observaciones

## Testing
- `npm test` *(frontend: MISSING DEPENDENCY Cannot find dependency 'jsdom')*
- `npm test` *(server: connect ECONNREFUSED 127.0.0.1:5432)*

------
https://chatgpt.com/codex/tasks/task_e_68bfb7549a9c832eb009c42033317d83