### PR TITLE
Fix backend start scripts causing Railway 502 timeouts

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "jwt-decode": "^4.0.0"
   },
   "scripts": {
-  "start": "node index_app.js",
-  "dev": "nodemon index_app.js"
-}
+    "start": "node server/index.js",
+    "dev": "node server/index.js"
+  }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -4,9 +4,9 @@
   "type": "commonjs",
   "main": "index.js",
   "scripts": {
-    "test": "cross-env NODE_ENV=test vitest run",
+    "start": "node index.js",
     "dev": "node index.js",
-    "start": "node index.js"
+    "test": "cross-env NODE_ENV=test vitest run"
   },
   "keywords": [],
   "author": "",
@@ -34,8 +34,5 @@
     "cross-env": "^10.0.0",
     "supertest": "^7.1.4",
     "vitest": "^3.2.4"
-  },
-  "scripts": {
-  "start": "node index_app.js"
   }
 }


### PR DESCRIPTION
### Motivation
- Railway was returning 502 `connection dial timeout` because the deployed process started the wrong entrypoint and no process bound to `PORT` (the app was exported from `index_app.js` but not `listen`ed). 
- The change ensures the actual server that calls `app.listen(...)` is launched in production so the platform has a live listener.

### Description
- Updated root `package.json` `start` and `dev` scripts to run `node server/index.js` so the backend entrypoint that starts the HTTP listener is launched. 
- Fixed `server/package.json` `scripts` block to set `start` to `node index.js`, keep `dev` as `node index.js`, and restore the `test` script `cross-env NODE_ENV=test vitest run` in the same `scripts` object. 
- Removed the accidental use of `index_app.js` as the runtime entrypoint which only exports the Express app and does not call `listen`.

### Testing
- Ran `npm --prefix server run start` with a short timeout and confirmed the server boots and logs `Servidor ejecutándose en http://localhost:3000` (success). 
- Ran `npm --prefix server run test` which executed `tests/auth.test.js` and produced 2 passed / 1 failed; the failing test (`Auth API > login credenciales inválidas`) is due to `ECONNREFUSED` connecting to a local PostgreSQL instance (`::1:5432` and `127.0.0.1:5432`) in the test environment, not related to the scripts change (test failure expected when DB is unavailable).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb5d3f58cc833284dd83d917faa62b)