### PR TITLE
Handle missing Google OAuth config, add frontend message, and tidy server scripts/CORS

### DIFF
--- a/frontend/src/pages/auth/Login.jsx
+++ b/frontend/src/pages/auth/Login.jsx
@@ -36,6 +36,8 @@ export default function Login() {
     const errorParam = searchParams.get("error");
     if (errorParam === "google") {
       setError("Tu cuenta de Google no está autorizada para ingresar al sistema.");
+    } else if (errorParam === "google_config") {
+      setError("El acceso con Google no está configurado en el servidor. Contacta al administrador.");
     }
   }, [searchParams]);
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "jwt-decode": "^4.0.0"
   },
   "scripts": {
-  "start": "node index_app.js",
-  "dev": "nodemon index_app.js"
-}
+    "start": "node server/index.js",
+    "dev": "node server/index.js"
+  }
 }

--- a/server/config/passport.js
+++ b/server/config/passport.js
@@ -6,18 +6,29 @@ module.exports = function initPassport(passport) {
   const {
     GOOGLE_CLIENT_ID,
     GOOGLE_CLIENT_SECRET,
-    BACKEND_URL
+    BACKEND_URL,
+    GOOGLE_CALLBACK_URL,
+    RAILWAY_PUBLIC_DOMAIN
   } = process.env;
 
-  if (!GOOGLE_CLIENT_ID || !GOOGLE_CLIENT_SECRET || !BACKEND_URL) {
-    console.warn('Google OAuth environment variables missing, skipping strategy');
+  const callbackURL =
+    GOOGLE_CALLBACK_URL ||
+    (BACKEND_URL ? `${BACKEND_URL}/api/auth/google/callback` : null) ||
+    (RAILWAY_PUBLIC_DOMAIN ? `https://${RAILWAY_PUBLIC_DOMAIN}/api/auth/google/callback` : null);
+
+  if (!GOOGLE_CLIENT_ID || !GOOGLE_CLIENT_SECRET || !callbackURL) {
+    const missing = [];
+    if (!GOOGLE_CLIENT_ID) missing.push('GOOGLE_CLIENT_ID');
+    if (!GOOGLE_CLIENT_SECRET) missing.push('GOOGLE_CLIENT_SECRET');
+    if (!callbackURL) missing.push('GOOGLE_CALLBACK_URL o BACKEND_URL o RAILWAY_PUBLIC_DOMAIN');
+    console.warn(`Google OAuth environment variables missing, skipping strategy. Missing: ${missing.join(', ')}`);
     return;
   }
 
   passport.use(new Strategy({
     clientID: GOOGLE_CLIENT_ID,
     clientSecret: GOOGLE_CLIENT_SECRET,
-    callbackURL: `${BACKEND_URL}/api/auth/google/callback`
+    callbackURL
   },
   async (_accessToken, _refreshToken, profile, done) => {
     try {

--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -5,10 +5,25 @@ const db = require('../db');
 const bcrypt = require('bcryptjs');
 const jwt = require('jsonwebtoken');
 
+const frontendURL = process.env.FRONTEND_URL || 'https://pmp-control.pages.dev';
+const googleStrategyEnabled = () => !!passport._strategy('google');
 
-exports.startGoogleAuth = passport.authenticate('google', { scope: ['profile', 'email'] });
+exports.startGoogleAuth = (req, res, next) => {
+  if (!googleStrategyEnabled()) {
+    return res.status(503).json({
+      error: 'Google OAuth no está configurado en el servidor',
+      required: ['GOOGLE_CLIENT_ID', 'GOOGLE_CLIENT_SECRET', 'GOOGLE_CALLBACK_URL o BACKEND_URL']
+    });
+  }
+
+  return passport.authenticate('google', { scope: ['profile', 'email'] })(req, res, next);
+};
 
 exports.googleCallback = (req, res, next) => {
+  if (!googleStrategyEnabled()) {
+    return res.redirect(`${frontendURL}/login?error=google_config`);
+  }
+
   passport.authenticate('google', { session: false }, (err, user) => {
     console.log("🔁 Google Callback ejecutado");
     if (err) {
@@ -17,7 +32,7 @@ exports.googleCallback = (req, res, next) => {
     }
 
     if (!user) {
-      return res.redirect(`${process.env.FRONTEND_URL}/login?error=google`);
+      return res.redirect(`${frontendURL}/login?error=google`);
     }
 
     const rolId = Number(user.rol_id);
@@ -30,7 +45,7 @@ exports.googleCallback = (req, res, next) => {
 
     console.log("✅ Token generado:", token);
 
-    res.redirect(`${process.env.FRONTEND_URL}/auth/google/success?token=${token}`);
+    res.redirect(`${frontendURL}/auth/google/success?token=${token}`);
   })(req, res, next);
 };
 

--- a/server/index_app.js
+++ b/server/index_app.js
@@ -12,7 +12,7 @@ const path = require('path');
 const allowedOrigins = [
   "http://localhost:5173",
   "https://pmp-control.pages.dev", // dominio Cloudflare
-  "pmp-control-production.up.railway.app"
+  "https://pmp-control-production.up.railway.app"
   //"https://tu-dominio.cl"         // si luego usas dominio propio
 ];
 

--- a/server/package.json
+++ b/server/package.json
@@ -4,9 +4,9 @@
   "type": "commonjs",
   "main": "index.js",
   "scripts": {
-    "test": "cross-env NODE_ENV=test vitest run",
+    "start": "node index.js",
     "dev": "node index.js",
-    "start": "node index.js"
+    "test": "cross-env NODE_ENV=test vitest run"
   },
   "keywords": [],
   "author": "",
@@ -34,8 +34,5 @@
     "cross-env": "^10.0.0",
     "supertest": "^7.1.4",
     "vitest": "^3.2.4"
-  },
-  "scripts": {
-  "start": "node index_app.js"
   }
 }


### PR DESCRIPTION
### Motivation
- Improve robustness when Google OAuth environment variables are missing and provide clear feedback to users and admins.
- Surface a specific frontend error when Google auth is not configured on the server.
- Standardize server start scripts and fix CORS allowed origins to use full HTTPS domain.

### Description
- Added detection of missing Google OAuth configuration in `server/config/passport.js` and build a `callbackURL` from `GOOGLE_CALLBACK_URL`, `BACKEND_URL`, or `RAILWAY_PUBLIC_DOMAIN`, logging which env vars are missing and skipping the strategy when necessary.
- Introduced `googleStrategyEnabled` helper and guarded endpoints in `server/controllers/authController.js`, returning a `503` JSON error from `startGoogleAuth` when the strategy is not enabled and redirecting to the frontend with `?error=google_config` from `googleCallback`; also consolidated `FRONTEND_URL` usage into a `frontendURL` variable.
- Updated frontend `Login.jsx` to show a specific error banner message when `error=google_config` is present in the URL.
- Updated project `package.json` and `server/package.json` scripts to use `node server/index.js` and `node index.js` respectively for `start`/`dev`, and reordered the `test` script in the server package for consistency.
- Fixed CORS allowed origins in `server/index_app.js` to include the Railway production host with the `https://` scheme.

### Testing
- Ran the server test suite with `npm --prefix server run test` and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb5d3f58cc833284dd83d917faa62b)