### PR TITLE
Robust Google OAuth callback handling and frontend callback URL fix

### DIFF
--- a/frontend/src/pages/auth/GoogleSuccess.jsx
+++ b/frontend/src/pages/auth/GoogleSuccess.jsx
@@ -4,6 +4,8 @@ import axios from "axios";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { getRutaPorRol } from "../../utils/rutasPorRol";
 
+const apiUrl = import.meta.env.VITE_API_URL;
+
 export default function GoogleSuccess() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
@@ -17,10 +19,9 @@ export default function GoogleSuccess() {
       return;
     }
 
-    // Guardar token
     localStorage.setItem("token", token);
 
-    axios.get("http://localhost:3000/api/auth/me", {
+    axios.get(`${apiUrl}/auth/me`, {
       headers: {
         Authorization: `Bearer ${token}`,
       }
@@ -32,8 +33,9 @@ export default function GoogleSuccess() {
       })
       .catch((err) => {
         console.error("❌ Error al obtener usuario:", err);
-        localStorage.setItem("login_error", "Acceso de negado. Cuenta no registrada.");
-        navigate("/login");
+        localStorage.removeItem("token");
+        localStorage.setItem("login_error", "Acceso denegado. Cuenta no registrada.");
+        navigate("/login?error=google_server");
       });
   }, [navigate, searchParams]);
 

--- a/frontend/src/pages/auth/Login.jsx
+++ b/frontend/src/pages/auth/Login.jsx
@@ -37,7 +37,9 @@ export default function Login() {
     if (errorParam === "google") {
       setError("Tu cuenta de Google no está autorizada para ingresar al sistema.");
     } else if (errorParam === "google_config") {
-      setError("El acceso con Google no está configurado en el servidor. Contacta al administrador.");
+      setError("El acceso con Google no está configurado en el servidor. Verifica GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, GOOGLE_CALLBACK_URL/BACKEND_URL y JWT_SECRET.");
+    } else if (errorParam === "google_server") {
+      setError("El servidor no pudo completar el inicio de sesión con Google. Revisa los logs de Railway y la configuración de variables de entorno.");
     }
   }, [searchParams]);
 

--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -11,6 +11,23 @@ const frontendURL = process.env.FRONTEND_URL || (
     : 'http://localhost:5173'
 );
 const googleStrategyEnabled = () => !!passport._strategy('google');
+const jwtSecretConfigured = () => typeof process.env.JWT_SECRET === 'string' && process.env.JWT_SECRET.trim().length > 0;
+
+function redirectToLoginWithError(res, errorCode) {
+  return res.redirect(`${frontendURL}/login?error=${errorCode}`);
+}
+
+function buildAuthToken(user) {
+  if (!jwtSecretConfigured()) {
+    throw new Error('JWT_SECRET is not configured');
+  }
+
+  return jwt.sign(
+    { sub: user.id, email: user.email, rol_id: Number(user.rol_id) },
+    process.env.JWT_SECRET,
+    { expiresIn: '8h' }
+  );
+}
 
 exports.startGoogleAuth = (req, res, next) => {
   if (!googleStrategyEnabled()) {
@@ -25,31 +42,29 @@ exports.startGoogleAuth = (req, res, next) => {
 
 exports.googleCallback = (req, res, next) => {
   if (!googleStrategyEnabled()) {
-    return res.redirect(`${frontendURL}/login?error=google_config`);
+    return redirectToLoginWithError(res, 'google_config');
   }
 
   passport.authenticate('google', { session: false }, (err, user) => {
-    console.log("🔁 Google Callback ejecutado");
+    console.log('🔁 Google Callback ejecutado');
+
     if (err) {
-      console.error("❌ Error en callback:", err); // LOG CRÍTICO
-      return next(err);
+      console.error('❌ Error en callback de Google:', err);
+      return redirectToLoginWithError(res, 'google_server');
     }
 
     if (!user) {
-      return res.redirect(`${frontendURL}/login?error=google`);
+      return redirectToLoginWithError(res, 'google');
     }
 
-    const rolId = Number(user.rol_id);
-
-    const token = jwt.sign(
-      { sub: user.id, email: user.email, rol_id: rolId },
-      process.env.JWT_SECRET,
-      { expiresIn: '8h' }
-    );
-
-    console.log("✅ Token generado:", token);
-
-    res.redirect(`${frontendURL}/auth/google/success?token=${token}`);
+    try {
+      const token = buildAuthToken(user);
+      console.log('✅ Token generado para Google');
+      return res.redirect(`${frontendURL}/auth/google/success?token=${token}`);
+    } catch (tokenError) {
+      console.error('❌ No se pudo generar el token para Google:', tokenError);
+      return redirectToLoginWithError(res, 'google_config');
+    }
   })(req, res, next);
 };
 
@@ -81,20 +96,14 @@ exports.localLogin = async (req, res) => {
       return res.status(401).json({ error: 'Credenciales inválidas' });
     }
 
-    const rolId = Number(user.rol_id);
-
-    const token = jwt.sign(
-      { sub: user.id, email: user.email, rol_id: rolId },
-      process.env.JWT_SECRET,
-      { expiresIn: '8h' }
-    );
+    const token = buildAuthToken(user);
 
     return res.status(200).json({
       token,
       user: {
         id: user.id,
         email: user.email,
-        rol_id: rolId,
+        rol_id: Number(user.rol_id),
         rol_nombre: user.rol_nombre,
         nombre: user.nombre
       }
@@ -121,17 +130,15 @@ exports.me = async (req, res) => {
     const user = result.rows[0];
     if (!user) return res.status(404).json({ error: 'Usuario no encontrado' });
 
-    const rolId = Number(user.rol_id);
-
     return res.status(200).json({
       id: user.id,
       email: user.email,
       nombre: user.nombre,
-      rol_id: rolId,
+      rol_id: Number(user.rol_id),
       rol_nombre: user.rol_nombre
     });
   } catch (e) {
-    console.error("❌ Error en /me:", e);
+    console.error('❌ Error en /me:', e);
     return res.status(401).json({ error: 'Token inválido' });
   }
 };


### PR DESCRIPTION
### Motivation
- Evitar que el callback de Google deje un `500` crudo en producción cuando Passport o la generación de JWT fallan, y proporcionar errores más claros en la UI.
- Corregir la llamada del frontend que seguía apuntando a `http://localhost:3000` después del flujo de OAuth, lo que rompe el flujo en despliegues (Railway/producción).

### Description
- Centralicé la generación del JWT en `server/controllers/authController.js` con validación de `JWT_SECRET` y una función `buildAuthToken` para evitar emitir tokens sin secreto configurado.
- Cambié el manejo del callback de Google para no propagar un `500` directo: ahora se redirige al login con códigos de error explícitos (`google_config`, `google`, `google_server`) y logs más descriptivos.
- Actualicé `frontend/src/pages/auth/GoogleSuccess.jsx` para usar `VITE_API_URL` en lugar de `http://localhost:3000` al llamar a `/auth/me`, limpiar el token en caso de fallo y redirigir con un error legible.
- Mejoré los mensajes en `frontend/src/pages/auth/Login.jsx` para mostrar instrucciones útiles cuando el problema es de configuración (`GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_CALLBACK_URL`/`BACKEND_URL`, `JWT_SECRET`) o un fallo interno del flujo Google.

### Testing
- Ejecuté el build del frontend con `cd frontend && npm run build` y completó correctamente (produjo los assets de `dist`).
- Ejecuté los tests del servidor con `cd server && npm test` y los resultados fueron: 3 tests, 2 pasaron y 1 falló; la prueba `login credenciales inválidas` lanzó un `500` porque no hay PostgreSQL local y `pg` devolvió `ECONNREFUSED`, por lo que el fallo es de entorno (falta la DB) y no causado por estos cambios.
- Observaciones: los cambios evitan que errores de Passport/JWT generen un `500` sin contexto y mejoran la experiencia en producción mostrando errores manejables en la UI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbdd6a02bc832eb0ed801dee2a2c59)