### PR TITLE
Enhance CORS origin handling and support env-configured allowed origins; update server log

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -3,5 +3,5 @@ const app = require('./index_app');
 
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {
-  console.log(`Servidor ejecutándose en http://localhost:${PORT}`);
+  console.log(`Servidor ejecutándose en puerto ${PORT}`);
 });

--- a/server/index_app.js
+++ b/server/index_app.js
@@ -8,21 +8,47 @@ const evidenciasRoutes = require('./routes/evidenciasRoutes');
 const app = express();
 const path = require('path');
 
+function normalizeOrigin(origin) {
+  return typeof origin === 'string' ? origin.trim().replace(/\/$/, '') : null;
+}
+
+function collectAllowedOrigins() {
+  const origins = new Set([
+    'http://localhost:5173',
+    'https://pmp-control.pages.dev',
+    'https://pmp-control-production.up.railway.app'
+  ]);
+
+  [process.env.FRONTEND_URL, process.env.CORS_ORIGIN, process.env.CORS_ORIGINS]
+    .filter(Boolean)
+    .forEach((value) => {
+      value
+        .split(',')
+        .map(normalizeOrigin)
+        .filter(Boolean)
+        .forEach((origin) => origins.add(origin));
+    });
+
+  return origins;
+}
+
 //Middlewares base
-const allowedOrigins = [
-  "http://localhost:5173",
-  "https://pmp-control.pages.dev", // dominio Cloudflare
-  "https://pmp-control-production.up.railway.app"
-  //"https://tu-dominio.cl"         // si luego usas dominio propio
-];
+const allowedOrigins = collectAllowedOrigins();
 
 app.use(cors({
-  origin: function (origin, callback) {
-    if (!origin || allowedOrigins.includes(origin)) {
+  origin(origin, callback) {
+    if (!origin) {
       callback(null, true);
-    } else {
-      callback(new Error("Not allowed by CORS"));
+      return;
     }
+
+    const normalizedOrigin = normalizeOrigin(origin);
+    if (normalizedOrigin && allowedOrigins.has(normalizedOrigin)) {
+      callback(null, true);
+      return;
+    }
+
+    callback(new Error(`Not allowed by CORS: ${origin}`));
   },
   credentials: true,
 }));


### PR DESCRIPTION
### Motivation
- Make CORS origin handling more robust by normalizing origins and allowing configuration via environment variables. 
- Allow comma-separated origin lists from `FRONTEND_URL`, `CORS_ORIGIN`, or `CORS_ORIGINS` to avoid hard-coding values. 
- Improve startup log message to avoid printing a full URL and reflect only the port.

### Description
- Added `normalizeOrigin` and `collectAllowedOrigins` helpers to trim and strip trailing slashes and to build a `Set` of allowed origins from defaults plus `FRONTEND_URL`, `CORS_ORIGIN`, and `CORS_ORIGINS` environment variables. 
- Replaced the hard-coded `allowedOrigins` array with the `collectAllowedOrigins()` `Set`. 
- Updated the `cors` middleware `origin` callback to accept requests without an `Origin`, normalize incoming origins, check membership in the `Set`, and return a clearer error message when blocked. 
- Adjusted the server startup log in `server/index.js` to `console.log("Servidor ejecutándose en puerto ${PORT}")`.

### Testing
- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbfca597c0832e9c73b63db71a47ac)