### PR TITLE
Normalize CORS origins, collect env origins, and prefer IPv4 for Postgres DNS

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -1,5 +1,10 @@
+const dns = require('dns');
 const { Pool } = require('pg');
 require('dotenv').config();
+
+if (typeof dns.setDefaultResultOrder === 'function') {
+  dns.setDefaultResultOrder('ipv4first');
+}
 
 function buildConnectionString() {
   if (process.env.DATABASE_URL) {

--- a/server/index.js
+++ b/server/index.js
@@ -3,5 +3,5 @@ const app = require('./index_app');
 
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {
-  console.log(`Servidor ejecutándose en http://localhost:${PORT}`);
+  console.log(`Servidor ejecutándose en puerto ${PORT}`);
 });

--- a/server/index_app.js
+++ b/server/index_app.js
@@ -8,21 +8,47 @@ const evidenciasRoutes = require('./routes/evidenciasRoutes');
 const app = express();
 const path = require('path');
 
+function normalizeOrigin(origin) {
+  return typeof origin === 'string' ? origin.trim().replace(/\/$/, '') : null;
+}
+
+function collectAllowedOrigins() {
+  const origins = new Set([
+    'http://localhost:5173',
+    'https://pmp-control.pages.dev',
+    'https://pmp-control-production.up.railway.app'
+  ]);
+
+  [process.env.FRONTEND_URL, process.env.CORS_ORIGIN, process.env.CORS_ORIGINS]
+    .filter(Boolean)
+    .forEach((value) => {
+      value
+        .split(',')
+        .map(normalizeOrigin)
+        .filter(Boolean)
+        .forEach((origin) => origins.add(origin));
+    });
+
+  return origins;
+}
+
 //Middlewares base
-const allowedOrigins = [
-  "http://localhost:5173",
-  "https://pmp-control.pages.dev", // dominio Cloudflare
-  "https://pmp-control-production.up.railway.app"
-  //"https://tu-dominio.cl"         // si luego usas dominio propio
-];
+const allowedOrigins = collectAllowedOrigins();
 
 app.use(cors({
-  origin: function (origin, callback) {
-    if (!origin || allowedOrigins.includes(origin)) {
+  origin(origin, callback) {
+    if (!origin) {
       callback(null, true);
-    } else {
-      callback(new Error("Not allowed by CORS"));
+      return;
     }
+
+    const normalizedOrigin = normalizeOrigin(origin);
+    if (normalizedOrigin && allowedOrigins.has(normalizedOrigin)) {
+      callback(null, true);
+      return;
+    }
+
+    callback(new Error(`Not allowed by CORS: ${origin}`));
   },
   credentials: true,
 }));


### PR DESCRIPTION
### Motivation
- Ensure predictable Postgres DNS resolution by preferring IPv4 to avoid IPv6-related connection failures in some environments.
- Harden CORS handling by normalizing origins, supporting environment-configured origin lists, and allowing requests with no `Origin` header (CLI/same-origin scenarios).
- Make the server startup log message less misleading by removing a hardcoded `localhost` URL.

### Description
- Added `dns` usage in `server/db.js` and call `dns.setDefaultResultOrder('ipv4first')` when available to prefer IPv4 address order for database connections.
- Implemented `normalizeOrigin` and `collectAllowedOrigins` in `server/index_app.js` to trim and strip trailing slashes, build a `Set` of allowed origins including `FRONTEND_URL`, `CORS_ORIGIN`, and `CORS_ORIGINS` (comma-separated), and updated the `cors` middleware to validate against normalized origins and allow null origins.
- Updated the startup message in `server/index.js` to log the port only instead of a hardcoded `localhost` URL.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbfca597c0832e9c73b63db71a47ac)